### PR TITLE
chore: locking package json version of sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/CoinHippo-Labs/axelarscan-ui#readme",
   "dependencies": {
     "@antv/g6": "^4.6.4",
-    "@axelar-network/axelarjs-sdk": "^0.6.0-alpha.4",
+    "@axelar-network/axelarjs-sdk": "0.6.0-alpha.4",
     "@headlessui/react": "^1.6.4",
     "@redux-devtools/extension": "^3.2.2",
     "antd": "^4.20.6",


### PR DESCRIPTION
the only thing i did was resolve the package-json version to the specific version 4. for some reason, when it has the `^`, it resolves to the stable version that doesn't have the new API. 