### PR TITLE
feat: update GMPs and GMP page to query and display Coral's settlement events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "axelarscan-ui",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "axelarscan-ui",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "license": "MIT",
       "dependencies": {
-        "@axelar-network/axelarjs-sdk": "0.17.1-alpha.9",
+        "@axelar-network/axelarjs-sdk": "0.17.1",
         "@headlessui/react": "^1.7.19",
         "@headlessui/tailwindcss": "^0.2.0",
         "@mysten/dapp-kit": "^0.14.30",
@@ -200,9 +200,9 @@
       }
     },
     "node_modules/@axelar-network/axelarjs-sdk": {
-      "version": "0.17.1-alpha.9",
-      "resolved": "https://registry.npmjs.org/@axelar-network/axelarjs-sdk/-/axelarjs-sdk-0.17.1-alpha.9.tgz",
-      "integrity": "sha512-cyCWF04sY/b0HMdlBurFz7nAsgQE2H7Lm1WyPDYMqw8MkWFw3lP/VWwFgjyPP+39zMjTC5qZ/F7BaNMBf3lEOA==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@axelar-network/axelarjs-sdk/-/axelarjs-sdk-0.17.1.tgz",
+      "integrity": "sha512-cfV9gcx/OOsySL+K6UasSH2jczMc+ng1XZxeQAJ3r8c+/jdLEZ9mPUfoRBm1A37OILiieHjoy/K9H3bNcMjesg==",
       "hasInstallScript": true,
       "dependencies": {
         "@axelar-network/axelar-cgp-solidity": "^6.3.0",
@@ -212,7 +212,8 @@
         "@ethersproject/abstract-provider": "^5.7.0",
         "@ethersproject/networks": "^5.7.1",
         "@ethersproject/providers": "^5.7.2",
-        "@stellar/stellar-sdk": "^12.3.0",
+        "@mysten/sui": "^1.14.2",
+        "@stellar/stellar-sdk": "^13.0.0",
         "@types/uuid": "^8.3.1",
         "bech32": "^2.0.0",
         "clone-deep": "^4.0.1",
@@ -223,43 +224,6 @@
         "string-similarity-js": "^2.1.4",
         "uuid": "^8.3.2",
         "ws": "^8.13.0"
-      }
-    },
-    "node_modules/@axelar-network/axelarjs-sdk/node_modules/@stellar/stellar-sdk": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-12.3.0.tgz",
-      "integrity": "sha512-F2DYFop/M5ffXF0lvV5Ezjk+VWNKg0QDX8gNhwehVU3y5LYA3WAY6VcCarMGPaG9Wdgoeh1IXXzOautpqpsltw==",
-      "dependencies": {
-        "@stellar/stellar-base": "^12.1.1",
-        "axios": "^1.7.7",
-        "bignumber.js": "^9.1.2",
-        "eventsource": "^2.0.2",
-        "randombytes": "^2.1.0",
-        "toml": "^3.0.0",
-        "urijs": "^1.19.1"
-      }
-    },
-    "node_modules/@axelar-network/axelarjs-sdk/node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/@axelar-network/axelarjs-sdk/node_modules/form-data": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/@axelar-network/axelarjs-types": {
@@ -9997,22 +9961,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-3.1.2.tgz",
       "integrity": "sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ=="
-    },
-    "node_modules/@stellar/stellar-base": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-12.1.1.tgz",
-      "integrity": "sha512-gOBSOFDepihslcInlqnxKZdIW9dMUO1tpOm3AtJR33K2OvpXG6SaVHCzAmCFArcCqI9zXTEiSoh70T48TmiHJA==",
-      "dependencies": {
-        "@stellar/js-xdr": "^3.1.2",
-        "base32.js": "^0.1.0",
-        "bignumber.js": "^9.1.2",
-        "buffer": "^6.0.3",
-        "sha.js": "^2.3.6",
-        "tweetnacl": "^1.0.3"
-      },
-      "optionalDependencies": {
-        "sodium-native": "^4.1.1"
-      }
     },
     "node_modules/@stellar/stellar-sdk": {
       "version": "13.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axelarscan-ui",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Axelarscan UI",
   "scripts": {
     "dev": "next dev",

--- a/src/components/GMP.jsx
+++ b/src/components/GMP.jsx
@@ -113,7 +113,7 @@ function Info({ data, estimatedTimeSpent, executeData, buttons, tx, lite }) {
   const [seeMore, setSeeMore] = useState(false)
   const { chains, assets } = useGlobalStore()
 
-  const { call, gas_paid, gas_paid_to_callback, express_executed, confirm, approved, executed, error, refunded, token_sent, token_deployment_initialized, token_deployed, interchain_transfer, interchain_transfer_with_data, interchain_transfers, token_manager_deployment_started, interchain_token_deployment_started, is_executed, amount, fees, gas, is_insufficient_fee, is_invalid_destination_chain, is_invalid_source_address, is_invalid_contract_address, not_enough_gas_to_execute, status, simplified_status, time_spent, callbackData, originData } = { ...data }
+  const { call, gas_paid, gas_paid_to_callback, express_executed, confirm, approved, executed, error, refunded, token_sent, token_deployment_initialized, token_deployed, interchain_transfer, interchain_transfer_with_data, token_manager_deployment_started, interchain_token_deployment_started, settlement_forwarded_events, settlement_filled_events, interchain_transfers, is_executed, amount, fees, gas, is_insufficient_fee, is_invalid_destination_chain, is_invalid_source_address, is_invalid_contract_address, not_enough_gas_to_execute, status, simplified_status, time_spent, callbackData, originData, settlementForwardedData, settlementFilledData } = { ...data }
   const { proposal_id } = { ...call }
   const txhash = call?.transactionHash || tx
 
@@ -329,6 +329,116 @@ function Info({ data, estimatedTimeSpent, executeData, buttons, tx, lite }) {
               </dd>
             </div>
           )}
+          {((settlement_forwarded_events && executed) || (settlement_filled_events && data.settlementForwardedData)) && (
+            <div className="px-4 sm:px-6 py-6 sm:grid sm:grid-cols-4 sm:gap-4">
+              <dt className="text-zinc-900 dark:text-zinc-100 text-sm font-medium">Settlement Status</dt>
+              <dd className="sm:col-span-3 text-zinc-700 dark:text-zinc-300 text-sm leading-6 mt-1 sm:mt-0">
+                <div className="overflow-x-auto sm:grid sm:grid-cols-4 gap-x-4">
+                  <div className="flex justify-between gap-x-4">
+                    <div className="flex flex-col gap-y-4">
+                      <span className="text-blue-600 dark:text-blue-500 text-2xs font-medium whitespace-nowrap">Settlement Forwarded</span>
+                      <div className="flex flex-col gap-y-3">
+                        {settlement_forwarded_events ?
+                          <ExplorerLink
+                            value={txhash}
+                            chain={sourceChain}
+                            title={ellipse(txhash, 6, '0x')}
+                            iconOnly={false}
+                          /> :
+                          toArray(data.settlementForwardedData).map((d, i) => (
+                            <ExplorerLink
+                              key={i}
+                              value={d.call.transactionHash}
+                              chain="axelarnet"
+                              customURL={`/gmp/${d.message_id}`}
+                              title={ellipse(d.call.transactionHash, 6, '0x')}
+                              iconOnly={false}
+                            />
+                          ))
+                        }
+                      </div>
+                    </div>
+                    <MdKeyboardArrowRight size={24} />
+                  </div>
+                  <div className="flex justify-between gap-x-4">
+                    <div className="flex flex-col gap-y-4">
+                      <span className="text-blue-600 dark:text-blue-500 text-2xs font-medium whitespace-nowrap">Settlement Processed</span>
+                      <div className="flex flex-col gap-y-3">
+                        {settlement_forwarded_events ?
+                          <ExplorerLink
+                            value={executed.transactionHash}
+                            chain={destinationChain}
+                            title={ellipse(executed.transactionHash, 6, '0x')}
+                            iconOnly={false}
+                          /> :
+                          toArray(data.settlementForwardedData).map((d, i) => (
+                            <ExplorerLink
+                              key={i}
+                              value={d.executed.transactionHash}
+                              chain={d.executed.chain}
+                              title={ellipse(d.executed.transactionHash, 6, '0x')}
+                              iconOnly={false}
+                            />
+                          ))
+                        }
+                      </div>
+                    </div>
+                    <MdKeyboardArrowRight size={24} />
+                  </div>
+                  <div className="flex justify-between gap-x-4">
+                    <div className="flex flex-col gap-y-4">
+                      <span className="text-blue-600 dark:text-blue-500 text-2xs font-medium whitespace-nowrap">Settlement Filled</span>
+                      <div className="flex flex-col gap-y-3">
+                        {settlement_filled_events ?
+                          <ExplorerLink
+                            value={txhash}
+                            chain={sourceChain}
+                            title={ellipse(txhash, 6, '0x')}
+                            iconOnly={false}
+                          /> :
+                          toArray(data.settlementFilledData).map((d, i) => (
+                            <ExplorerLink
+                              key={i}
+                              value={d.call.transactionHash}
+                              chain="axelarnet"
+                              customURL={`/gmp/${d.message_id}`}
+                              title={ellipse(d.call.transactionHash, 6, '0x')}
+                              iconOnly={false}
+                            />
+                          ))
+                        }
+                      </div>
+                    </div>
+                    <MdKeyboardArrowRight size={24} />
+                  </div>
+                  <div className="flex justify-between gap-x-4">
+                    <div className="flex flex-col gap-y-4">
+                      <span className="text-blue-600 dark:text-blue-500 text-2xs font-medium whitespace-nowrap">Tokens Released</span>
+                      <div className="flex flex-col gap-y-3">
+                        {settlement_filled_events ?
+                          <ExplorerLink
+                            value={executed.transactionHash}
+                            chain={destinationChain}
+                            title={ellipse(executed.transactionHash, 6, '0x')}
+                            iconOnly={false}
+                          /> :
+                          toArray(data.settlementFilledData).map((d, i) => (
+                            <ExplorerLink
+                              key={i}
+                              value={d.executed.transactionHash}
+                              chain={d.executed.chain}
+                              title={ellipse(d.executed.transactionHash, 6, '0x')}
+                              iconOnly={false}
+                            />
+                          ))
+                        }
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </dd>
+            </div>
+          )}
           {isMultihop ?
             <div className="px-4 sm:px-6 py-6 sm:grid sm:grid-cols-4 sm:gap-4">
               <dt className="text-zinc-900 dark:text-zinc-100 text-sm font-medium">Path</dt>
@@ -399,7 +509,7 @@ function Info({ data, estimatedTimeSpent, executeData, buttons, tx, lite }) {
           )}
           {toArray(interchain_transfers).length > 0 && (
             <div className="px-4 sm:px-6 py-6 sm:grid sm:grid-cols-4 sm:gap-4">
-              <dt className="text-zinc-900 dark:text-zinc-100 text-sm font-medium">Events</dt>
+              <dt className="text-zinc-900 dark:text-zinc-100 text-sm font-medium">Settlement Filled</dt>
               <dd className="sm:col-span-3 text-zinc-700 dark:text-zinc-300 text-sm leading-6 mt-1 sm:mt-0">
                 <div className="flex flex-col gap-y-1.5">
                   {interchain_transfers.map((d, i) => {
@@ -1594,6 +1704,48 @@ export function GMP({ tx, lite }) {
             toArray([_d.express_executed?.messageId, _d.executed?.messageId, _d.executed?.returnValues?.messageId]).findIndex(id => equalsIgnoreCase(id, d.call.parentMessageID)) > -1
           )
           d.originData = await customData(d.originData)
+        }
+
+        // settlement filled
+        if (d.settlement_forwarded_events) {
+          const size = 10
+          let i = 0
+          let from = 0
+          let total
+          let data = []
+
+          while ((!isNumber(total) || total > data.length || from < total) && i < 10) {
+            const response = { ...await searchGMP({ event: 'SquidCoralSettlementFilled', squidCoralOrderHash: d.settlement_forwarded_events.map(e => e.orderHash), from, size }) }
+            if (isNumber(response.total)) total = response.total
+            if (response.data) {
+              data = _.uniqBy(_.concat(data, response.data), 'id')
+              from = data.length
+            }
+            else break
+            i++
+          }
+          if (data.length > 0) d.settlementFilledData = data
+        }
+
+        // settlement forwarded
+        if (d.settlement_filled_events) {
+          const size = 10
+          let i = 0
+          let from = 0
+          let total
+          let data = []
+
+          while ((!isNumber(total) || total > data.length || from < total) && i < 10) {
+            const response = { ...await searchGMP({ event: 'SquidCoralSettlementForwarded', squidCoralOrderHash: d.settlement_filled_events.map(e => e.orderHash), from, size }) }
+            if (isNumber(response.total)) total = response.total
+            if (response.data) {
+              data = _.uniqBy(_.concat(data, response.data), 'id')
+              from = data.length
+            }
+            else break
+            i++
+          }
+          if (data.length > 0) d.settlementForwardedData = data
         }
 
         console.log('[data]', d)

--- a/src/components/GMP.jsx
+++ b/src/components/GMP.jsx
@@ -332,7 +332,7 @@ function Info({ data, estimatedTimeSpent, executeData, buttons, tx, lite }) {
           {((settlement_forwarded_events && executed) || (settlement_filled_events && data.settlementForwardedData)) && (
             <div className="px-4 sm:px-6 py-6 sm:grid sm:grid-cols-4 sm:gap-4">
               <dt className="text-zinc-900 dark:text-zinc-100 text-sm font-medium">Settlement Status</dt>
-              <dd className="sm:col-span-3 text-zinc-700 dark:text-zinc-300 text-sm leading-6 mt-1 sm:mt-0">
+              <dd className="sm:col-span-3 text-zinc-700 dark:text-zinc-300 text-sm leading-6 mt-1 sm:mt-1.5">
                 <div className="overflow-x-auto sm:grid sm:grid-cols-4 gap-x-4">
                   <div className="flex justify-between gap-x-4">
                     <div className="flex flex-col gap-y-4">
@@ -358,7 +358,7 @@ function Info({ data, estimatedTimeSpent, executeData, buttons, tx, lite }) {
                         }
                       </div>
                     </div>
-                    <MdKeyboardArrowRight size={24} />
+                    <MdKeyboardArrowRight size={14} />
                   </div>
                   <div className="flex justify-between gap-x-4">
                     <div className="flex flex-col gap-y-4">
@@ -383,7 +383,7 @@ function Info({ data, estimatedTimeSpent, executeData, buttons, tx, lite }) {
                         }
                       </div>
                     </div>
-                    <MdKeyboardArrowRight size={24} />
+                    <MdKeyboardArrowRight size={14} />
                   </div>
                   <div className="flex justify-between gap-x-4">
                     <div className="flex flex-col gap-y-4">
@@ -409,7 +409,7 @@ function Info({ data, estimatedTimeSpent, executeData, buttons, tx, lite }) {
                         }
                       </div>
                     </div>
-                    <MdKeyboardArrowRight size={24} />
+                    <MdKeyboardArrowRight size={14} />
                   </div>
                   <div className="flex justify-between gap-x-4">
                     <div className="flex flex-col gap-y-4">

--- a/src/components/GMPs.jsx
+++ b/src/components/GMPs.jsx
@@ -68,7 +68,8 @@ function Filters() {
     { label: 'Asset Type', name: 'assetType', type: 'select', options: _.concat({ title: 'Any' }, [{ value: 'gateway', title: 'Gateway Token' }, { value: 'its', title: 'ITS Token' }]) },
     { label: 'Asset', name: 'asset', type: 'select', multiple: true, options: _.orderBy(toArray(_.concat(params.assetType !== 'its' && toArray(assets).map(d => ({ value: d.id, title: `${d.symbol} (${d.id})` })), params.assetType !== 'gateway' && toArray(itsAssets).map(d => ({ value: d.symbol, title: `${d.symbol} (ITS)` })))), ['title'], ['asc']) },
     params.assetType === 'its' && { label: 'ITS Token Address', name: 'itsTokenAddress' },
-    { label: 'Method', name: 'contractMethod', type: 'select', options: _.concat({ title: 'Any' }, [{ value: 'callContract', title: 'CallContract' }, { value: 'callContractWithToken', title: 'CallContractWithToken' }, { value: 'InterchainTransfer', title: 'InterchainTransfer' }, { value: 'InterchainTokenDeployment', title: 'InterchainTokenDeployment' }, { value: 'TokenManagerDeployment', title: 'TokenManagerDeployment' }]) },
+    { label: 'Method', name: 'contractMethod', type: 'select', options: _.concat({ title: 'Any' }, [{ value: 'callContract', title: 'CallContract' }, { value: 'callContractWithToken', title: 'CallContractWithToken' }, { value: 'InterchainTransfer', title: 'InterchainTransfer' }, { value: 'InterchainTokenDeployment', title: 'InterchainTokenDeployment' }, { value: 'TokenManagerDeployment', title: 'TokenManagerDeployment' }, { value: 'SquidCoral', title: 'SquidCoral' }, { value: 'SquidCoralSettlementForwarded', title: 'SquidCoralSettlementForwarded' }, { value: 'SquidCoralSettlementFilled', title: 'SquidCoralSettlementFilled' }]) },
+    params.contractMethod?.startsWith('SquidCoral') && { label: 'Squid Coral OrderHash', name: 'squidCoralOrderHash' },
     { label: 'Status', name: 'status', type: 'select', options: _.concat({ title: 'Any' }, [{ value: 'called', title: 'Called' }, { value: 'confirming', title: 'Wait for Confirmation' }, { value: 'express_executed', title: 'Express Executed' }, { value: 'approving', title: 'Wait for Approval' }, { value: 'approved', title: 'Approved' }, { value: 'executing', title: 'Executing' }, { value: 'executed', title: 'Executed' }, { value: 'error', title: 'Error Execution' }, { value: 'insufficient_fee', title: 'Insufficient Fee' }, { value: 'not_enough_gas_to_execute', title: 'Not Enough Gas' }]) },
     { label: 'Sender', name: 'senderAddress' },
     { label: 'Contract', name: 'contractAddress' },
@@ -241,12 +242,14 @@ function Filters() {
 }
 
 export const getEvent = data => {
-  const { call, token_sent, token_deployment_initialized, token_deployed, token_manager_deployment_started, interchain_token_deployment_started, interchain_transfer, interchain_transfer_with_data, interchain_transfers } = { ...data }
-  if (token_sent || interchain_transfer || interchain_transfer_with_data || interchain_transfers) return 'InterchainTransfer'
+  const { call, token_sent, token_deployment_initialized, token_deployed, token_manager_deployment_started, interchain_token_deployment_started, interchain_transfer, interchain_transfer_with_data, settlement_forwarded_events, settlement_filled_events, interchain_transfers } = { ...data }
+  if (token_sent || interchain_transfer || interchain_transfer_with_data) return 'InterchainTransfer'
   if (token_deployment_initialized) return 'TokenDeploymentInitialized'
   if (token_deployed) return 'TokenDeployed'
   if (token_manager_deployment_started) return 'TokenManagerDeployment'
   if (interchain_token_deployment_started) return 'InterchainTokenDeployment'
+  if (settlement_forwarded_events) return 'SquidCoralSettlementForwarded'
+  if (settlement_filled_events || interchain_transfers) return 'SquidCoralSettlementFilled'
   return call?.event
 }
 export const normalizeEvent = event => event?.replace('ContractCall', 'callContract')

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -165,7 +165,7 @@ function MobileNavigation() {
   )
 }
 
-function EnvirontmentLink({ name, href, children }) {
+function EnvironmentLink({ name, href, children }) {
   return (
     <Link
       href={href}
@@ -299,7 +299,7 @@ export function Header() {
                 >
                   <Popover.Panel className="absolute left-1/2 z-10 flex w-screen max-w-min -translate-x-1/2">
                     <div className="shrink rounded-xl bg-white dark:bg-zinc-800 p-2 text-sm shadow-lg ring-1 ring-zinc-900/5">
-                      {environments.map((d, i) => <EnvirontmentLink key={i} {...d}>{d.name}</EnvirontmentLink>)}
+                      {environments.map((d, i) => <EnvironmentLink key={i} {...d}>{d.name}</EnvironmentLink>)}
                     </div>
                   </Popover.Panel>
                 </Transition>

--- a/src/components/Interchain.jsx
+++ b/src/components/Interchain.jsx
@@ -796,7 +796,7 @@ function Top({
 }) {
   const { chains } = useGlobalStore()
   return (
-    <div className={clsx('border-l border-r border-t border-zinc-200 dark:border-zinc-700 flex flex-col gap-y-3 px-4 sm:px-6', type === 'chain' ? i % 3 !== 0 ? 'sm:border-l-0' : i % 6 !== 0 ? 'lg:border-l-0' : '' : !hasTransfers || !hasGMP || i % 4 !== 0 ? 'sm:border-l-0' : '', type === 'chain' ? 'xl:px-4 py-4' : 'xl:px-8 py-8')}>
+    <div className={clsx('border-l border-r border-t border-zinc-200 dark:border-zinc-700 flex flex-col gap-y-3 px-4 sm:px-6', type === 'chain' ? i % 3 !== 0 ? 'sm:border-l-0' : i % (hasTransfers ? 6 : 3) !== 0 ? 'lg:border-l-0' : '' : !hasTransfers || !hasGMP || i % 4 !== 0 ? 'sm:border-l-0' : '', type === 'chain' ? 'xl:px-4 py-4' : 'xl:px-8 py-8')}>
       <div className="flex flex-col gap-y-0.5">
         <span className="text-zinc-900 dark:text-zinc-100 text-sm font-semibold">
           {title}
@@ -981,6 +981,7 @@ function Tops({ data, types, params }) {
           <Top
             i={0}
             data={getTopData(chainPairs, 'num_txs', 100)}
+            hasTransfers={hasTransfers}
             hasGMP={hasGMP}
             title="Top Paths"
             description="by transactions"
@@ -989,6 +990,7 @@ function Tops({ data, types, params }) {
           <Top
             i={1}
             data={getTopData(sourceChains, 'num_txs', 100)}
+            hasTransfers={hasTransfers}
             hasGMP={hasGMP}
             title="Top Sources"
             description="by transactions"
@@ -997,6 +999,7 @@ function Tops({ data, types, params }) {
           <Top
             i={2}
             data={getTopData(destionationChains, 'num_txs', 100)}
+            hasTransfers={hasTransfers}
             hasGMP={hasGMP}
             title="Top Destinations"
             description="by transactions"
@@ -1005,6 +1008,7 @@ function Tops({ data, types, params }) {
           <Top
             i={3}
             data={getTopData(chainPairs, 'volume', 100)}
+            hasTransfers={hasTransfers}
             hasGMP={hasGMP}
             field="volume"
             title="Top Paths"
@@ -1015,6 +1019,7 @@ function Tops({ data, types, params }) {
           <Top
             i={4}
             data={getTopData(sourceChains, 'volume', 100)}
+            hasTransfers={hasTransfers}
             hasGMP={hasGMP}
             field="volume"
             title="Top Sources"
@@ -1025,6 +1030,7 @@ function Tops({ data, types, params }) {
           <Top
             i={5}
             data={getTopData(destionationChains, 'volume', 100)}
+            hasTransfers={hasTransfers}
             hasGMP={hasGMP}
             field="volume"
             title="Top Destinations"
@@ -1090,7 +1096,7 @@ function Tops({ data, types, params }) {
             </>
           )}
         </div>
-        {hasITS && (
+        {hasITS && !equalsIgnoreCase(params?.contractMethod, 'SquidCoral') && (
           <div className={clsx('grid sm:grid-cols-2 lg:grid-cols-4', !hasTransfers && 'lg:col-span-2')}>
             <Top
               i={0}
@@ -1434,6 +1440,16 @@ export function Interchain() {
                     className="text-xs"
                   />
                 ))}
+                {!contractAddress && equalsIgnoreCase(contractMethod, 'SquidCoral') && (
+                  <Profile
+                    address={accounts.find(d => equalsIgnoreCase(d.name, 'Squid Coral'))?.address}
+                    width={18}
+                    height={18}
+                    noCopy={true}
+                    customURL={`/gmp/search?contractMethod=${contractMethod}`}
+                    className="text-xs"
+                  />
+                )}
               </div>
               <div className="max-w-xl flex flex-wrap items-center mt-2">
                 {timeShortcuts.map((d, i) => {

--- a/src/components/Interchain.jsx
+++ b/src/components/Interchain.jsx
@@ -80,6 +80,7 @@ function Filters() {
     { label: 'From / To Chain', name: 'chain', type: 'select', multiple: true, options: _.orderBy(toArray(chains).map((d, i) => ({ ...d, i })), ['deprecated', 'name', 'i'], ['desc', 'asc', 'asc']).map(d => ({ value: d.id, title: `${d.name}${d.deprecated ? ` (deprecated)` : ''}` })) },
     { label: 'Asset', name: 'asset', type: 'select', multiple: true, options: _.orderBy(toArray(_.concat(params.assetType !== 'its' && toArray(assets).map(d => ({ value: d.id, title: `${d.symbol} (${d.id})` })), params.assetType !== 'gateway' && toArray(itsAssets).map(d => ({ value: d.symbol, title: `${d.symbol} (ITS)` })))), ['title'], ['asc']) },
     params.assetType === 'its' && { label: 'ITS Token Address', name: 'itsTokenAddress' },
+    { label: 'Method', name: 'contractMethod', type: 'select', options: _.concat({ title: 'Any' }, [{ value: 'callContract', title: 'CallContract' }, { value: 'callContractWithToken', title: 'CallContractWithToken' }, { value: 'InterchainTransfer', title: 'InterchainTransfer' }, { value: 'SquidCoral', title: 'SquidCoral' }]) },
     { label: 'Contract', name: 'contractAddress' },
     { label: 'Asset Type', name: 'assetType', type: 'select', options: _.concat({ title: 'Any' }, [{ value: 'gateway', title: 'Gateway Token' }, { value: 'its', title: 'ITS Token' }]) },
     { label: 'Time', name: 'time', type: 'datetimeRange' },
@@ -1270,8 +1271,9 @@ export function Interchain() {
   const globalStore = useGlobalStore()
   const { assets, stats } = { ...globalStore }
 
-  const { transfersType, contractAddress, fromTime, toTime } = { ...params }
-  const types = toArray(transfersType || ['gmp', 'transfers'])
+  const { transfersType, contractMethod, contractAddress, fromTime, toTime } = { ...params }
+  let types = toArray(transfersType || ['gmp', 'transfers'])
+  if (contractMethod) types = ['gmp']
   const granularity = getGranularity(fromTime, toTime)
 
   useEffect(() => {

--- a/src/data/accounts/index.js
+++ b/src/data/accounts/index.js
@@ -478,7 +478,31 @@ const data = [
     environment: 'mainnet',
   },
   {
+    address: '0xDdDDD043bD7A886a26C1231e4305582faB219667',
+    name: 'Squid Coral',
+    image: '/logos/accounts/squid.svg',
+    environment: 'mainnet',
+  },
+  {
+    address: '0x83077a68EA6955f2948520Eca1a2Fa2943925685',
+    name: 'Squid Coral',
+    image: '/logos/accounts/squid.svg',
+    environment: 'mainnet',
+  },
+  {
     address: '0x3A394B6678D24C5680E845EEb8e1cbdb7815E247',
+    name: 'Squid CoralHub',
+    image: '/logos/accounts/squid.svg',
+    environment: 'mainnet',
+  },
+  {
+    address: '0xAC12f4fCFd3b73b8D9613dDD5136b4aA28A76248',
+    name: 'Squid CoralHub',
+    image: '/logos/accounts/squid.svg',
+    environment: 'mainnet',
+  },
+  {
+    address: '0xe6B3949F9bBF168f4E3EFc82bc8FD849868CC6d8',
     name: 'Squid CoralHub',
     image: '/logos/accounts/squid.svg',
     environment: 'mainnet',

--- a/src/data/accounts/index.js
+++ b/src/data/accounts/index.js
@@ -472,6 +472,18 @@ const data = [
     environment: 'mainnet',
   },
   {
+    address: '0xA4cE01bD7Dd91DA968a7C4A8D04282a3f5eA06bB',
+    name: 'Squid Coral',
+    image: '/logos/accounts/squid.svg',
+    environment: 'mainnet',
+  },
+  {
+    address: '0x3A394B6678D24C5680E845EEb8e1cbdb7815E247',
+    name: 'Squid CoralHub',
+    image: '/logos/accounts/squid.svg',
+    environment: 'mainnet',
+  },
+  {
     address: '0x66423a1b45e14EaB8B132665FebC7Ec86BfcBF44',
     name: 'The Junkyard',
     image: '/logos/accounts/junkyard.png',


### PR DESCRIPTION
### Description 
This PR 
- adds support querying and displays Coral transactions' information. The updates impacts 2 GMP main pages, which are the detailed page and the list view. 
- labels Squid's Coral addresses

More details can be found in [this document](https://www.notion.so/bright-ambert-2bd/GMP-API-UI-Support-extracting-the-Squid-s-Coral-customized-events-18bc53fccb77803cb498d78a62a7d7c8?pvs=4#18bc53fccb7780a4bdcadb043916a792).