### PR TITLE
feat: update extract recipient from cosmos payload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "axelarscan-ui",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "axelarscan-ui",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "license": "MIT",
       "dependencies": {
         "@axelar-network/axelarjs-sdk": "0.17.3-alpha.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axelarscan-ui",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Axelarscan UI",
   "scripts": {
     "dev": "next dev",

--- a/src/components/GMPs.jsx
+++ b/src/components/GMPs.jsx
@@ -261,8 +261,10 @@ export const customData = async data => {
 
   try {
     const { id, name, customize } = { ...toArray(customGMPs).find(d => toArray(d.addresses).findIndex(a => equalsIgnoreCase(a, destinationContractAddress)) > -1 && (!d.environment || equalsIgnoreCase(d.environment, ENVIRONMENT))) }
+
     if (typeof customize === 'function') {
-      const customValues = await customize(call.returnValues, ENVIRONMENT)
+      const customValues = await customize(call.returnValues, ENVIRONMENT, data)
+
       if (typeof customValues === 'object' && !Array.isArray(customValues) && Object.keys({ ...customValues }).length > 0) {
         customValues.projectId = id
         customValues.projectName = name || capitalize(id)
@@ -271,12 +273,28 @@ export const customData = async data => {
     }
 
     // interchain transfer
-    if (interchain_transfer?.destinationAddress && !data.customValues?.recipientAddress) data.customValues = { ...data.customValues, recipientAddress: interchain_transfer.destinationAddress, destinationChain: interchain_transfer.destinationChain, projectId: 'its', projectName: 'ITS' }
+    if (interchain_transfer?.destinationAddress && !data.customValues?.recipientAddress) {
+      data.customValues = {
+        ...data.customValues,
+        recipientAddress: interchain_transfer.destinationAddress,
+        destinationChain: interchain_transfer.destinationChain,
+        projectId: 'its',
+        projectName: 'ITS',
+      }
+    }
 
     // interchain transfers
-    if (toArray(interchain_transfers).length > 0 && !data.customValues?.recipientAddresses)
-      data.customValues = { ...data.customValues, recipientAddresses: interchain_transfers.map(d => ({ recipientAddress: d.recipient, chain: d.destinationChain })) }
+    if (toArray(interchain_transfers).length > 0 && !data.customValues?.recipientAddresses) {
+      data.customValues = {
+        ...data.customValues,
+        recipientAddresses: interchain_transfers.map(d => ({
+          recipientAddress: d.recipient,
+          chain: d.destinationChain,
+        })),
+      }
+    }
   } catch (error) {}
+
   return data
 }
 

--- a/src/data/accounts/index.js
+++ b/src/data/accounts/index.js
@@ -1002,7 +1002,7 @@ const data = [
   {address:'axelar1p0z7ff4wru5yq0v2ny5h6vx5e6ceg06kqnhfpg',name:'Axelar',environment:'mainnet'},
   {
     address: 'osmo1n6ney9tsf55etz9nrmzyd8wa7e64qd3s06a74fqs30ka8pps6cvqtsycr6',
-    name: 'Squid Multicall Contract',
+    name: 'Squid',
     image: '/logos/accounts/squid.svg',
   },
   {

--- a/src/data/custom/gmp/index.js
+++ b/src/data/custom/gmp/index.js
@@ -16,10 +16,16 @@ const customs = [
     id: 'squid',
     name: 'Squid',
     addresses: ['0xce16F69375520ab01377ce7B88f5BA8C48F8D666', '0xDC3D8e1Abe590BCa428a8a2FC4CfDbD1AcF57Bd9', '0x492751eC3c57141deb205eC2da8bFcb410738630', 'osmo15jw7xccxaxk30lf4xgag8f7aeg53pgkh74e39rv00xfnymldjaas2fk627', '0x481A2AAE41cd34832dDCF5A79404538bb2c02bC8', '0xc3468a191fe51815b26535ed1f82c1f79e6ec37d', 'osmo1zl9ztmwe2wcdvv9std8xn06mdaqaqm789rutmazfh3z869zcax4sv0ctqw'],
-    customize: async (eventData, environment) => {
+    customize: async (eventData, environment, GMPData) => {
       const { destinationContractAddress, payload } = { ...eventData }
+      const { chain_type } = { ...GMPData?.call }
+
       const customValues = {}
-      if (destinationContractAddress.startsWith('0x')) customValues.recipientAddress = `0x${payload.substring(90, 130)}`
+
+      if (destinationContractAddress.startsWith('0x')) {
+        customValues.recipientAddress = `0x${chain_type === 'cosmos' ? payload.substring(26, 66) : payload.substring(90, 130)}`
+      }
+
       return customValues
     },
   },

--- a/src/lib/provider/wagmi.js
+++ b/src/lib/provider/wagmi.js
@@ -12,7 +12,7 @@ export const CHAINS = toArray(process.env.NEXT_PUBLIC_ENVIRONMENT === 'mainnet' 
     { _id: 'polygon', ...polygon },
     { _id: 'polygon-zkevm', ...polygonZkEvm },
     { _id: 'avalanche', ...avalanche },
-    { _id: 'fantom', ...fantom, rpcUrls: { default: { http: ['https://rpc.ftm.tools'] } } },
+    { _id: 'fantom', ...fantom, rpcUrls: { default: { http: ['https://rpc.fantom.network'] } } },
     { _id: 'moonbeam', ...moonbeam },
     { _id: 'aurora', ...aurora },
     { _id: 'arbitrum', ...arbitrum },


### PR DESCRIPTION
### Description
The recipient address for Squid calls is shown as 0x1, which is incorrect. https://axelarscan.io/gmp/0xeaf90d7b2f5d6a1ffe59b322eaf40f4127835486c3a5b94d16684e1f5dae6fe3-266532

### Root cause
We notice a different payload pattern compared to GMP transactions originating from an EVM chain.

### Action
Implement an additional parsing pattern to handle GMP transactions originating from Cosmos chains.