### PR TITLE
feat: activate add gas button when insufficient gas error on another hop

### DIFF
--- a/src/components/GMP.jsx
+++ b/src/components/GMP.jsx
@@ -1960,12 +1960,12 @@ export function GMP({ tx, lite }) {
               d.settlementForwardedData = data
             }
           }
+
+          console.log('[data]', d)
+          setData(d)
+
+          return d
         }
-
-        console.log('[data]', d)
-        setData(d)
-
-        return d
       }
     }
 

--- a/src/components/GMP.jsx
+++ b/src/components/GMP.jsx
@@ -29,7 +29,7 @@ import { Profile, ChainProfile, AssetProfile } from '@/components/Profile'
 import { TimeAgo, TimeSpent, TimeUntil } from '@/components/Time'
 import { ExplorerLink } from '@/components/ExplorerLink'
 import { useEVMWalletStore, EVMWallet, useCosmosWalletStore, CosmosWallet, useSuiWalletStore, SuiWallet, useStellarWalletStore, StellarWallet, useXRPLWalletStore, XRPLWallet } from '@/components/Wallet'
-import { getEvent, customData } from '@/components/GMPs'
+import { getEvent, customData, checkNeedMoreGasFromError } from '@/components/GMPs'
 import { useGlobalStore } from '@/components/Global'
 import { estimateITSFee, searchGMP, estimateTimeSpent } from '@/lib/api/gmp'
 import { isAxelar } from '@/lib/chain'
@@ -37,7 +37,7 @@ import { getProvider } from '@/lib/chain/evm'
 import { ENVIRONMENT, getChainData, getAssetData } from '@/lib/config'
 import { toCase, split, toArray, parseError } from '@/lib/parser'
 import { sleep, getParams } from '@/lib/operator'
-import { isString, equalsIgnoreCase, headString, find, includesSomePatterns, ellipse, toTitle } from '@/lib/string'
+import { isString, equalsIgnoreCase, headString, find, ellipse, toTitle } from '@/lib/string'
 import { isNumber, toNumber, toBigNumber, formatUnits, parseUnits, numberFormat } from '@/lib/number'
 import { timeDiff } from '@/lib/time'
 import IAxelarExecutable from '@/data/interfaces/gmp/IAxelarExecutable.json'
@@ -1839,121 +1839,126 @@ export function GMP({ tx, lite }) {
       const d = await customData(_.head(data))
 
       if (d) {
-        if (['received', 'failed'].includes(d.simplified_status) && (d.executed || d.error) && (d.refunded || d.not_to_refund)) {
-          setEnded(true)
+        if (d.call?.parentMessageID) {
+          router.push(`/gmp/${d.call.parentMessageID}`)
         }
+        else {
+          if (['received', 'failed'].includes(d.simplified_status) && (d.executed || d.error) && (d.refunded || d.not_to_refund)) {
+            setEnded(true)
+          }
 
-        // callback
-        if (d.callback?.transactionHash) {
-          const { data } = { ...await searchGMP({
-            txHash: d.callback.transactionHash,
-            txIndex: d.callback.transactionIndex,
-            txLogIndex: d.callback.logIndex,
-          }) }
-
-          d.callbackData = toArray(data).find(_d => equalsIgnoreCase(_d.call?.transactionHash, d.callback.transactionHash))
-          d.callbackData = await customData(d.callbackData)
-        }
-        else if (d.executed?.transactionHash) {
-          const { data } = { ...await searchGMP({ txHash: d.executed.transactionHash }) }
-
-          d.callbackData = toArray(data).find(_d => equalsIgnoreCase(_d.call?.transactionHash, d.executed.transactionHash))
-          d.callbackData = await customData(d.callbackData)
-        }
-        else if (d.callback?.messageIdHash) {
-          const messageId = `${d.callback.messageIdHash}-${d.callback.messageIdIndex}`
-          const { data } = { ...await searchGMP({ messageId }) }
-
-          d.callbackData = toArray(data).find(_d => equalsIgnoreCase(_d.call?.returnValues?.messageId, messageId))
-          d.callbackData = await customData(d.callbackData)
-        }
-        else if (toArray(d.executed?.childMessageIDs) > 0) {
-          const { data } = { ...await searchGMP({ messageId: _.head(d.executed.childMessageIDs) }) }
-
-          d.callbackData = toArray(data).find(_d => equalsIgnoreCase(_d.call?.returnValues?.messageId, _.head(d.executed.childMessageIDs)))
-          d.callbackData = await customData(d.callbackData)
-        }
-
-        // origin
-        if (d.call && (d.gas_paid_to_callback || d.is_call_from_relayer)) {
-          const { data } = { ...await searchGMP(d.call.transactionHash ? { txHash: d.call.transactionHash } : { messageId: d.call.parentMessageID }) }
-
-          d.originData = toArray(data).find(_d => d.call.transactionHash ?
-            toArray([_d.express_executed?.transactionHash, _d.executed?.transactionHash]).findIndex(tx => equalsIgnoreCase(tx, d.call.transactionHash)) > -1 :
-            toArray([_d.express_executed?.messageId, _d.executed?.messageId, _d.executed?.returnValues?.messageId]).findIndex(id => equalsIgnoreCase(id, d.call.parentMessageID)) > -1
-          )
-          d.originData = await customData(d.originData)
-        }
-
-        // settlement filled
-        if (d.settlement_forwarded_events) {
-          const size = 10
-          let i = 0
-          let from = 0
-          let total
-          let data = []
-
-          while ((!isNumber(total) || total > data.length || from < total) && i < 10) {
-            const response = { ...await searchGMP({
-              event: 'SquidCoralSettlementFilled',
-              squidCoralOrderHash: d.settlement_forwarded_events.map(e => e.orderHash),
-              from,
-              size,
+          // callback
+          if (d.callback?.transactionHash) {
+            const { data } = { ...await searchGMP({
+              txHash: d.callback.transactionHash,
+              txIndex: d.callback.transactionIndex,
+              txLogIndex: d.callback.logIndex,
             }) }
 
-            if (isNumber(response.total)) {
-              total = response.total
-            }
+            d.callbackData = toArray(data).find(_d => equalsIgnoreCase(_d.call?.transactionHash, d.callback.transactionHash))
+            d.callbackData = await customData(d.callbackData)
+          }
+          else if (d.executed?.transactionHash) {
+            const { data } = { ...await searchGMP({ txHash: d.executed.transactionHash }) }
 
-            if (response.data) {
-              data = _.uniqBy(_.concat(data, response.data), 'id')
-              from = data.length
-            }
-            else {
-              break
-            }
+            d.callbackData = toArray(data).find(_d => equalsIgnoreCase(_d.call?.transactionHash, d.executed.transactionHash))
+            d.callbackData = await customData(d.callbackData)
+          }
+          else if (d.callback?.messageIdHash) {
+            const messageId = `${d.callback.messageIdHash}-${d.callback.messageIdIndex}`
+            const { data } = { ...await searchGMP({ messageId }) }
 
-            i++
+            d.callbackData = toArray(data).find(_d => equalsIgnoreCase(_d.call?.returnValues?.messageId, messageId))
+            d.callbackData = await customData(d.callbackData)
+          }
+          else if (toArray(d.executed?.childMessageIDs) > 0) {
+            const { data } = { ...await searchGMP({ messageId: _.head(d.executed.childMessageIDs) }) }
+
+            d.callbackData = toArray(data).find(_d => equalsIgnoreCase(_d.call?.returnValues?.messageId, _.head(d.executed.childMessageIDs)))
+            d.callbackData = await customData(d.callbackData)
           }
 
-          if (data.length > 0) {
-            d.settlementFilledData = data
-          }
-        }
+          // origin
+          if (d.call && (d.gas_paid_to_callback || d.is_call_from_relayer)) {
+            const { data } = { ...await searchGMP(d.call.transactionHash ? { txHash: d.call.transactionHash } : { messageId: d.call.parentMessageID }) }
 
-        // settlement forwarded
-        if (d.settlement_filled_events) {
-          const size = 10
-          let i = 0
-          let from = 0
-          let total
-          let data = []
-
-          while ((!isNumber(total) || total > data.length || from < total) && i < 10) {
-            const response = { ...await searchGMP({
-              event: 'SquidCoralSettlementForwarded',
-              squidCoralOrderHash: d.settlement_filled_events.map(e => e.orderHash),
-              from,
-              size,
-            }) }
-
-            if (isNumber(response.total)) {
-              total = response.total
-            }
-
-            if (response.data) {
-              data = _.uniqBy(_.concat(data, response.data), 'id')
-              from = data.length
-            }
-            else {
-              break
-            }
-
-            i++
+            d.originData = toArray(data).find(_d => d.call.transactionHash ?
+              toArray([_d.express_executed?.transactionHash, _d.executed?.transactionHash]).findIndex(tx => equalsIgnoreCase(tx, d.call.transactionHash)) > -1 :
+              toArray([_d.express_executed?.messageId, _d.executed?.messageId, _d.executed?.returnValues?.messageId]).findIndex(id => equalsIgnoreCase(id, d.call.parentMessageID)) > -1
+            )
+            d.originData = await customData(d.originData)
           }
 
-          if (data.length > 0) {
-            d.settlementForwardedData = data
+          // settlement filled
+          if (d.settlement_forwarded_events) {
+            const size = 10
+            let i = 0
+            let from = 0
+            let total
+            let data = []
+
+            while ((!isNumber(total) || total > data.length || from < total) && i < 10) {
+              const response = { ...await searchGMP({
+                event: 'SquidCoralSettlementFilled',
+                squidCoralOrderHash: d.settlement_forwarded_events.map(e => e.orderHash),
+                from,
+                size,
+              }) }
+
+              if (isNumber(response.total)) {
+                total = response.total
+              }
+
+              if (response.data) {
+                data = _.uniqBy(_.concat(data, response.data), 'id')
+                from = data.length
+              }
+              else {
+                break
+              }
+
+              i++
+            }
+
+            if (data.length > 0) {
+              d.settlementFilledData = data
+            }
+          }
+
+          // settlement forwarded
+          if (d.settlement_filled_events) {
+            const size = 10
+            let i = 0
+            let from = 0
+            let total
+            let data = []
+
+            while ((!isNumber(total) || total > data.length || from < total) && i < 10) {
+              const response = { ...await searchGMP({
+                event: 'SquidCoralSettlementForwarded',
+                squidCoralOrderHash: d.settlement_filled_events.map(e => e.orderHash),
+                from,
+                size,
+              }) }
+
+              if (isNumber(response.total)) {
+                total = response.total
+              }
+
+              if (response.data) {
+                data = _.uniqBy(_.concat(data, response.data), 'id')
+                from = data.length
+              }
+              else {
+                break
+              }
+
+              i++
+            }
+
+            if (data.length > 0) {
+              d.settlementForwardedData = data
+            }
           }
         }
 
@@ -2522,7 +2527,7 @@ export function GMP({ tx, lite }) {
         (
           data.callbackData && (
             // some patterns of error is detected
-            data.callbackData.error && includesSomePatterns([data.callbackData.error.error?.reason, data.callbackData.error.error?.message], ['INSUFFICIENT_GAS'])
+            checkNeedMoreGasFromError(data.callbackData.error)
           )
         ))
       ) {

--- a/src/components/GMPs.jsx
+++ b/src/components/GMPs.jsx
@@ -456,7 +456,7 @@ export function GMPs({ address }) {
                         <div className="flex items-center gap-x-1">
                           <Copy value={key}>
                             <Link
-                              href={`/gmp/${d.message_id ? d.message_id : `${d.call.chain_type === 'cosmos' && isNumber(d.call.messageIdIndex) ? d.call.axelarTransactionHash : d.call.transactionHash}${isNumber(d.call.logIndex) ? `:${d.call.logIndex}` : d.call.chain_type === 'cosmos' && isNumber(d.call.messageIdIndex) ? `-${d.call.messageIdIndex}` : ''}`}`}
+                              href={`/gmp/${d.call.parentMessageID ? d.call.parentMessageID : d.message_id ? d.message_id : `${d.call.chain_type === 'cosmos' && isNumber(d.call.messageIdIndex) ? d.call.axelarTransactionHash : d.call.transactionHash}${isNumber(d.call.logIndex) ? `:${d.call.logIndex}` : d.call.chain_type === 'cosmos' && isNumber(d.call.messageIdIndex) ? `-${d.call.messageIdIndex}` : ''}`}`}
                               target="_blank"
                               className="text-blue-600 dark:text-blue-500 font-semibold"
                             >

--- a/src/components/GMPs.jsx
+++ b/src/components/GMPs.jsx
@@ -33,7 +33,7 @@ import { isAxelar } from '@/lib/chain'
 import { ENVIRONMENT } from '@/lib/config'
 import { split, toArray } from '@/lib/parser'
 import { getParams, getQueryString, generateKeyByParams, isFiltered } from '@/lib/operator'
-import { isString, equalsIgnoreCase, capitalize, toBoolean, ellipse } from '@/lib/string'
+import { isString, equalsIgnoreCase, capitalize, toBoolean, includesSomePatterns, ellipse } from '@/lib/string'
 import { isNumber } from '@/lib/number'
 import customGMPs from '@/data/custom/gmp'
 
@@ -340,6 +340,8 @@ export const customData = async data => {
 
   return data
 }
+
+export const checkNeedMoreGasFromError = error => !!error && includesSomePatterns([error.error?.reason, error.error?.message], ['INSUFFICIENT_GAS'])
 
 export function GMPs({ address }) {
   const searchParams = useSearchParams()


### PR DESCRIPTION
### Description
This PR addresses the issue where the gas paid is sufficient for the 1st hop, while insufficient at the 2nd hop. So this PR adds the functionality that lets the explorer UI to check the conditions of another hop transfer to activate the Add Gas button. There are also other changes to accommodate this functionality.
- When opening with a 2nd hop link, the UI auto-redirects to the 1st hop link instead (to accommodate adding gas to the 1st hop)


### Test results
Tested on transactions stuck on testnet for this specific scenario. They went through successfully. 
- https://axelarscan-testnet-git-feat-addgasbutton-axelar-network.vercel.app/gmp/0x1a0313aff7be1964a331ccdfce647da4b37bef2644b9442cfcbeac05fb4d8351