### PR TITLE
chore: wait for assets data loaded when filtering asset

### DIFF
--- a/src/components/Interchain.jsx
+++ b/src/components/Interchain.jsx
@@ -1568,7 +1568,7 @@ export function Interchain() {
     const metrics = ['GMPStatsByChains', 'GMPStatsByContracts', 'GMPChart', 'GMPTotalVolume', 'GMPTopUsers', 'GMPTopITSUsers', 'GMPTopITSUsersByVolume', 'GMPTopITSAssets', 'GMPTopITSAssetsByVolume', 'transfersStats', 'transfersChart', 'transfersTotalVolume', 'transfersTopUsers', 'transfersTopUsersByVolume']
 
     const getData = async () => {
-      // assets data need when filtering asset
+      // assets data require when filtering asset
       if (params && toBoolean(refresh) && stats && (!params.asset || (assets && globalStore.itsAssets))) {
         setData({
           ...data,


### PR DESCRIPTION
### Description
This PR adds a wait for asset data to be fully loaded before performing a search. Previously, there was an issue where the filter wasn’t applied correctly, resulting in token transfer records being incorrectly included in the results.

Slack: https://interoplabs.slack.com/archives/C035KBHNP8A/p1751905193104799?thread_ts=1751900553.625819&cid=C035KBHNP8A