### PR TITLE
Build Correct TX URL for Stellar

### DIFF
--- a/src/components/AmplifierPoll.jsx
+++ b/src/components/AmplifierPoll.jsx
@@ -14,7 +14,7 @@ import { Tag } from '@/components/Tag'
 import { Number } from '@/components/Number'
 import { Profile, ChainProfile } from '@/components/Profile'
 import { TimeAgo } from '@/components/Time'
-import { ExplorerLink } from '@/components/ExplorerLink'
+import { ExplorerLink, buildExplorerURL } from '@/components/ExplorerLink'
 import { useGlobalStore } from '@/components/Global'
 import { getRPCStatus, searchAmplifierPolls } from '@/lib/api/validator'
 import { getChainData } from '@/lib/config'
@@ -28,7 +28,9 @@ function Info({ data, id }) {
 
   const { contract_address, transaction_id, event_index, sender_chain, status, height, initiated_txhash, confirmation_txhash, completed_txhash, expired_height, participants, voteOptions, created_at, updated_at } = { ...data }
 
-  const { url, transaction_path } = { ...getChainData(sender_chain, chains)?.explorer }
+  const explorer = { ...getChainData(sender_chain, chains)?.explorer }
+
+  const txHref = buildExplorerURL({ value: transaction_id, type: 'tx', useContractLink: false, hasEventLog: false, explorer });
 
   return (
     <div className="overflow-hidden bg-zinc-50/75 dark:bg-zinc-800/25 shadow sm:rounded-lg">
@@ -43,7 +45,7 @@ function Info({ data, id }) {
             <div className="flex items-center gap-x-1">
               <Copy value={transaction_id}>
                 <Link
-                  href={`${url}${transaction_path?.replace('{tx}', transaction_id)}`}
+                  href={txHref}
                   target="_blank"
                   className="text-blue-600 dark:text-blue-500 font-semibold"
                 >

--- a/src/components/AmplifierPolls.jsx
+++ b/src/components/AmplifierPolls.jsx
@@ -445,7 +445,7 @@ export function AmplifierPolls() {
               <tbody className="bg-white dark:bg-zinc-900 divide-y divide-zinc-100 dark:divide-zinc-800">
                 {data.map(d => {
                   const explorer = { ...getChainData(d.sender_chain, chains)?.explorer }
-                  const txHref = buildExplorerURL(d.transaction_id, 'tx', false, false, explorer)
+                  const txHref = buildExplorerURL({ value: d.transaction_id, type: 'tx', useContractLink: false, hasEventLog: false, explorer })
 
                   return (
                     <tr key={d.id} className="align-top text-zinc-400 dark:text-zinc-500 text-sm">

--- a/src/components/AmplifierPolls.jsx
+++ b/src/components/AmplifierPolls.jsx
@@ -20,7 +20,7 @@ import { Spinner } from '@/components/Spinner'
 import { Tag } from '@/components/Tag'
 import { Number } from '@/components/Number'
 import { ChainProfile } from '@/components/Profile'
-import { ExplorerLink } from '@/components/ExplorerLink'
+import { ExplorerLink, buildExplorerURL } from '@/components/ExplorerLink'
 import { TimeAgo } from '@/components/Time'
 import { Pagination } from '@/components/Pagination'
 import { useGlobalStore } from '@/components/Global'
@@ -444,7 +444,8 @@ export function AmplifierPolls() {
               </thead>
               <tbody className="bg-white dark:bg-zinc-900 divide-y divide-zinc-100 dark:divide-zinc-800">
                 {data.map(d => {
-                  const { url, transaction_path } = { ...getChainData(d.sender_chain, chains)?.explorer }
+                  const explorer = { ...getChainData(d.sender_chain, chains)?.explorer }
+                  const txHref = buildExplorerURL(d.transaction_id, 'tx', false, false, explorer)
 
                   return (
                     <tr key={d.id} className="align-top text-zinc-400 dark:text-zinc-500 text-sm">
@@ -463,7 +464,7 @@ export function AmplifierPolls() {
                             <div className="flex items-center gap-x-1">
                               <Copy value={d.transaction_id}>
                                 <Link
-                                  href={`${url}${transaction_path?.replace('{tx}', d.transaction_id)}`}
+                                  href={txHref}
                                   target="_blank"
                                   className="text-blue-600 dark:text-blue-500 font-semibold"
                                 >

--- a/src/components/ExplorerLink.jsx
+++ b/src/components/ExplorerLink.jsx
@@ -43,7 +43,7 @@ export const buildExplorerURL = ({ value, type, useContractLink, hasEventLog, ex
       }
 
       suffix = ''
-      if (hasEventLog && value?.startsWith('0x')) {
+      if (hasEventLog && processedValue?.startsWith('0x')) {
         suffix = '#eventlog'
       }
 

--- a/src/components/ExplorerLink.jsx
+++ b/src/components/ExplorerLink.jsx
@@ -15,38 +15,46 @@ import { isNumber } from '@/lib/number'
 export const buildExplorerURL = ({ value, type, useContractLink, hasEventLog, explorer }) => {
   const { url, address_path, contract_path, contract_0_path, transaction_path, block_path, no_0x, cannot_link_contract_via_address_path } = { ...explorer }
 
-  // Return undefined if url or value are falsy
+  // Return a fallback URL if url or value are falsy
   if (!url || !value) {
-    return undefined
+    return '#'
   }
 
   let path
   let href
-  let processedValue = value
+  let processedValue
+  let suffix
 
   switch (type) {
     case 'address':
       path = useContractLink && cannot_link_contract_via_address_path && contract_path ? contract_path : address_path
-      href = `${url}${path?.replace(`{address}`, processedValue)}`
+      href = `${url}${path?.replace(`{address}`, value)}`
       break;
     case 'contract':
       path = (value === ZeroAddress && contract_0_path) || contract_path
-      href = `${url}${path?.replace(`{address}`, processedValue)}`
+      href = `${url}${path?.replace(`{address}`, value)}`
       break;
     case 'tx':
       path = transaction_path
-      // remove prefix 0x
-      if (no_0x && processedValue?.startsWith('0x')) {
-        processedValue = processedValue.substring(2)
+
+      processedValue = value
+      if (no_0x && value?.startsWith('0x')) {
+        processedValue = value.substring(2)
       }
-      href = `${url}${path?.replace(`{tx}`, processedValue)}${processedValue.startsWith('0x') && hasEventLog ? '#eventlog' : ''}`
+
+      suffix = ''
+      if (hasEventLog && value?.startsWith('0x')) {
+        suffix = '#eventlog'
+      }
+
+      href = `${url}${path?.replace(`{tx}`, processedValue)}${suffix}`
       break;
     case 'block':
       path = block_path
-      href = `${url}${path?.replace(`{block}`, processedValue)}`
+      href = `${url}${path?.replace(`{block}`, value)}`
       break;
     default:
-      return undefined
+      return '#'
   }
 
   return href

--- a/src/components/ExplorerLink.jsx
+++ b/src/components/ExplorerLink.jsx
@@ -12,32 +12,44 @@ import { getInputType } from '@/lib/parser'
 import { isString } from '@/lib/string'
 import { isNumber } from '@/lib/number'
 
-export const buildExplorerURL = (value, type, useContractLink, hasEventLog, explorer) => {
+export const buildExplorerURL = ({ value, type, useContractLink, hasEventLog, explorer }) => {
   const { url, address_path, contract_path, contract_0_path, transaction_path, block_path, no_0x, cannot_link_contract_via_address_path } = { ...explorer }
 
+  // Return undefined if url or value are falsy
+  if (!url || !value) {
+    return undefined
+  }
+
   let path
+  let href
   let processedValue = value
 
   switch (type) {
     case 'address':
       path = useContractLink && cannot_link_contract_via_address_path && contract_path ? contract_path : address_path
-      return `${url}${path?.replace(`{address}`, processedValue)}`
+      href = `${url}${path?.replace(`{address}`, processedValue)}`
+      break;
     case 'contract':
       path = (value === ZeroAddress && contract_0_path) || contract_path
-      return `${url}${path?.replace(`{address}`, processedValue)}`
+      href = `${url}${path?.replace(`{address}`, processedValue)}`
+      break;
     case 'tx':
       path = transaction_path
       // remove prefix 0x
       if (no_0x && processedValue?.startsWith('0x')) {
         processedValue = processedValue.substring(2)
       }
-      return `${url}${path?.replace(`{tx}`, processedValue)}${value.startsWith('0x') && hasEventLog ? '#eventlog' : ''}`
+      href = `${url}${path?.replace(`{tx}`, processedValue)}${processedValue.startsWith('0x') && hasEventLog ? '#eventlog' : ''}`
+      break;
     case 'block':
       path = block_path
-      return `${url}${path?.replace(`{block}`, processedValue)}`
+      href = `${url}${path?.replace(`{block}`, processedValue)}`
+      break;
     default:
       return undefined
   }
+
+  return href
 }
 
 export function ExplorerLink({
@@ -74,9 +86,11 @@ export function ExplorerLink({
     }
   }
 
-  let href = customURL || buildExplorerURL(value, type, useContractLink, hasEventLog, explorer)
+  const href = customURL || buildExplorerURL({ value, type, useContractLink, hasEventLog, explorer })
 
-  return href && (
+  if (!href) { return null }
+
+  return (
     <Link
       href={href}
       target="_blank"

--- a/src/components/ExplorerLink.jsx
+++ b/src/components/ExplorerLink.jsx
@@ -12,6 +12,34 @@ import { getInputType } from '@/lib/parser'
 import { isString } from '@/lib/string'
 import { isNumber } from '@/lib/number'
 
+export const buildExplorerURL = (value, type, useContractLink, hasEventLog, explorer) => {
+  const { url, address_path, contract_path, contract_0_path, transaction_path, block_path, no_0x, cannot_link_contract_via_address_path } = { ...explorer }
+
+  let path
+  let processedValue = value
+
+  switch (type) {
+    case 'address':
+      path = useContractLink && cannot_link_contract_via_address_path && contract_path ? contract_path : address_path
+      return `${url}${path?.replace(`{address}`, processedValue)}`
+    case 'contract':
+      path = (value === ZeroAddress && contract_0_path) || contract_path
+      return `${url}${path?.replace(`{address}`, processedValue)}`
+    case 'tx':
+      path = transaction_path
+      // remove prefix 0x
+      if (no_0x && processedValue?.startsWith('0x')) {
+        processedValue = processedValue.substring(2)
+      }
+      return `${url}${path?.replace(`{tx}`, processedValue)}${value.startsWith('0x') && hasEventLog ? '#eventlog' : ''}`
+    case 'block':
+      path = block_path
+      return `${url}${path?.replace(`{block}`, processedValue)}`
+    default:
+      return undefined
+  }
+}
+
 export function ExplorerLink({
   value,
   chain,
@@ -29,7 +57,6 @@ export function ExplorerLink({
 }) {
   const { chains } = useGlobalStore()
   const { explorer } = { ...getChainData(chain, chains) }
-  const { url, name, block_path, address_path, contract_path, contract_0_path, transaction_path, icon, no_0x, cannot_link_contract_via_address_path } = { ...explorer }
 
   if (type === 'tx') {
     // update type from input value
@@ -47,46 +74,21 @@ export function ExplorerLink({
     }
   }
 
-  let path
-  let field = type
+  let href = customURL || buildExplorerURL(value, type, useContractLink, hasEventLog, explorer)
 
-  // set explorer path by input type
-  switch (type) {
-    case 'address':
-      path = useContractLink && cannot_link_contract_via_address_path && contract_path ? contract_path : address_path
-      break
-    case 'contract':
-      path = (value === ZeroAddress && contract_0_path) || contract_path
-      field = 'address'
-      break
-    case 'tx':
-      path = transaction_path
-
-      // remove prefix 0x
-      if (no_0x && value?.startsWith('0x')) {
-        value = value.substring(2)
-      }
-      break
-    case 'block':
-      path = block_path
-      break
-    default:
-      break
-  }
-
-  return (customURL || (url && value)) && (
+  return href && (
     <Link
-      href={customURL || `${url}${path?.replace(`{${field}}`, value)}${type === 'tx' && value.startsWith('0x') && hasEventLog ? '#eventlog' : ''}`}
+      href={href}
       target="_blank"
       className={clsx('min-w-max flex items-center gap-x-2', containerClassName)}
     >
       {!iconOnly && (
         <span className={clsx('font-medium', nonIconClassName)}>
-          {title || `View on ${name}`}
+          {title || `View on ${explorer.name}`}
         </span>
       )}
       <Image
-        src={icon}
+        src={explorer.icon}
         alt=""
         width={width}
         height={height}


### PR DESCRIPTION
In the Amplifier Polls page, in the case of Stellar we don't construct the url for the Stellar explorer correctly (we don't remove the `0x` prefix).

This change reuses the logic from the `ExplorerLink` component in order to correctly construct the url.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes explorer URL construction in `ExplorerLink` and updates Amplifier Poll views to use it for correct transaction links.
> 
> - **Explorer Link**:
>   - Add `buildExplorerURL` to generate explorer URLs for `address`, `contract`, `tx`, and `block`, handling `no_0x` and `#eventlog`.
>   - Refactor `ExplorerLink` to use `buildExplorerURL`, reference `explorer.name/icon`, and return early if no href.
> - **Amplifier Polls**:
>   - Replace manual tx URL concatenation with `buildExplorerURL` in `src/components/AmplifierPoll.jsx` and `src/components/AmplifierPolls.jsx` (and update imports).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7ee9ed9a4f1d61051e9b9edc3fcd4845e611619. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->