### PR TITLE
Add Metamask Snap Support for XRPL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@tanstack/react-query": "^5.74.11",
         "@xrpl-wallet-adapter/crossmark": "^0.1.4",
         "@xrpl-wallet-adapter/ledger": "^0.1.0",
+        "@xrpl-wallet-adapter/metamask": "^0.1.2",
         "@xrpl-wallet-adapter/walletconnect": "^0.2.0",
         "@xrpl-wallet-standard/react": "^0.2.4",
         "antd": "^5.24.9",
@@ -6783,7 +6784,6 @@
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/long": {
@@ -9365,6 +9365,179 @@
         "@xrpl-wallet-adapter/base": "0.1.4",
         "@xrpl-wallet-standard/core": "0.1.4",
         "xrpl": "^4.1.0"
+      }
+    },
+    "node_modules/@xrpl-wallet-adapter/metamask": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@xrpl-wallet-adapter/metamask/-/metamask-0.1.2.tgz",
+      "integrity": "sha512-3cZS6kTkUbPnlKBRo2CJsRxkuA9BdE0bHdgI6fsP8QRgW0ArofUMQ5k+3sCoqIq0DqOIk44Y148m71Z1TOTkDA==",
+      "license": "ISC",
+      "dependencies": {
+        "@metamask/providers": "^17.1.2",
+        "@wallet-standard/base": "1.0.1",
+        "@xrpl-wallet-adapter/base": "0.1.4",
+        "@xrpl-wallet-standard/core": "0.1.4",
+        "xrpl": "^4.0.0"
+      }
+    },
+    "node_modules/@xrpl-wallet-adapter/metamask/node_modules/@metamask/json-rpc-engine": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@metamask/json-rpc-engine/-/json-rpc-engine-9.0.3.tgz",
+      "integrity": "sha512-efeRXW7KaL0BJcAeudSGhzu6sD3hMpxx9nl3V+Yemm1bsyc66yVUhYPR+XH+Y6ZvB2p05ywgvd1Ev5PBwFzr/g==",
+      "license": "ISC",
+      "dependencies": {
+        "@metamask/rpc-errors": "^6.3.1",
+        "@metamask/safe-event-emitter": "^3.0.0",
+        "@metamask/utils": "^9.1.0"
+      },
+      "engines": {
+        "node": "^18.18 || >=20"
+      }
+    },
+    "node_modules/@xrpl-wallet-adapter/metamask/node_modules/@metamask/json-rpc-middleware-stream": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/@metamask/json-rpc-middleware-stream/-/json-rpc-middleware-stream-8.0.7.tgz",
+      "integrity": "sha512-s7ugj+b4QYkQ+3VjRDdsp8GfKOKrxvI6HzaZg4TJrfSV+SO/Ky4TGo4Aib1gtv3/8muCPYAPGtjFVYWVAVJ6jw==",
+      "license": "ISC",
+      "dependencies": {
+        "@metamask/json-rpc-engine": "^10.0.3",
+        "@metamask/safe-event-emitter": "^3.0.0",
+        "@metamask/utils": "^11.1.0",
+        "readable-stream": "^3.6.2"
+      },
+      "engines": {
+        "node": "^18.18 || >=20"
+      }
+    },
+    "node_modules/@xrpl-wallet-adapter/metamask/node_modules/@metamask/json-rpc-middleware-stream/node_modules/@metamask/json-rpc-engine": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@metamask/json-rpc-engine/-/json-rpc-engine-10.1.0.tgz",
+      "integrity": "sha512-VbX1RNdAQJG8HpTNfn5bC9VJkqf8tCIA8d9GWeM+hqt9sWUCpJ7HkDCqmCt1fB5hEm5oaDugGaJqIO3Z+Z4r5g==",
+      "license": "ISC",
+      "dependencies": {
+        "@metamask/rpc-errors": "^7.0.2",
+        "@metamask/safe-event-emitter": "^3.0.0",
+        "@metamask/utils": "^11.8.0"
+      },
+      "engines": {
+        "node": "^18.18 || >=20"
+      }
+    },
+    "node_modules/@xrpl-wallet-adapter/metamask/node_modules/@metamask/json-rpc-middleware-stream/node_modules/@metamask/rpc-errors": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@metamask/rpc-errors/-/rpc-errors-7.0.3.tgz",
+      "integrity": "sha512-nrEaeBawm8yFU7hetJKok/CUs0tQsWtTqp3OLbFhPUMXYqU7uI5LAV5vi9o7rTjFkUyof7Nzbw5bea5+1ou+dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@metamask/utils": "^11.4.2",
+        "fast-safe-stringify": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.20 || ^20.17 || >=22"
+      }
+    },
+    "node_modules/@xrpl-wallet-adapter/metamask/node_modules/@metamask/json-rpc-middleware-stream/node_modules/@metamask/utils": {
+      "version": "11.8.1",
+      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.8.1.tgz",
+      "integrity": "sha512-DIbsNUyqWLFgqJlZxi1OOCMYvI23GqFCvNJAtzv8/WXWzJfnJnvp1M24j7VvUe3URBi3S86UgQ7+7aWU9p/cnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@ethereumjs/tx": "^4.2.0",
+        "@metamask/superstruct": "^3.1.0",
+        "@noble/hashes": "^1.3.1",
+        "@scure/base": "^1.1.3",
+        "@types/debug": "^4.1.7",
+        "@types/lodash": "^4.17.20",
+        "debug": "^4.3.4",
+        "lodash": "^4.17.21",
+        "pony-cause": "^2.1.10",
+        "semver": "^7.5.4",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": "^18.18 || ^20.14 || >=22"
+      }
+    },
+    "node_modules/@xrpl-wallet-adapter/metamask/node_modules/@metamask/providers": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/@metamask/providers/-/providers-17.2.1.tgz",
+      "integrity": "sha512-xnF48ULB0uZ4mOPLMv5xzLWenMs1zbAUNP+wiBofetzIqnD/i6S8u9axIkAwEXBsb0JXtDI1lBPiTBJ5HUxRdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@metamask/json-rpc-engine": "^9.0.1",
+        "@metamask/json-rpc-middleware-stream": "^8.0.1",
+        "@metamask/object-multiplex": "^2.0.0",
+        "@metamask/rpc-errors": "^6.3.1",
+        "@metamask/safe-event-emitter": "^3.1.1",
+        "@metamask/utils": "^9.0.0",
+        "detect-browser": "^5.2.0",
+        "extension-port-stream": "^4.1.0",
+        "fast-deep-equal": "^3.1.3",
+        "is-stream": "^2.0.0",
+        "readable-stream": "^3.6.2"
+      },
+      "engines": {
+        "node": "^18.18 || >=20"
+      },
+      "peerDependencies": {
+        "webextension-polyfill": "^0.10.0 || ^0.11.0 || ^0.12.0"
+      }
+    },
+    "node_modules/@xrpl-wallet-adapter/metamask/node_modules/@metamask/utils": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-9.3.0.tgz",
+      "integrity": "sha512-w8CVbdkDrVXFJbfBSlDfafDR6BAkpDmv1bC1UJVCoVny5tW2RKAdn9i68Xf7asYT4TnUhl/hN4zfUiKQq9II4g==",
+      "license": "ISC",
+      "dependencies": {
+        "@ethereumjs/tx": "^4.2.0",
+        "@metamask/superstruct": "^3.1.0",
+        "@noble/hashes": "^1.3.1",
+        "@scure/base": "^1.1.3",
+        "@types/debug": "^4.1.7",
+        "debug": "^4.3.4",
+        "pony-cause": "^2.1.10",
+        "semver": "^7.5.4",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@xrpl-wallet-adapter/metamask/node_modules/@wallet-standard/base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/base/-/base-1.0.1.tgz",
+      "integrity": "sha512-1To3ekMfzhYxe0Yhkpri+Fedq0SYcfrOfJi3vbLjMwF2qiKPjTGLwZkf2C9ftdQmxES+hmxhBzTwF4KgcOwf8w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@xrpl-wallet-adapter/metamask/node_modules/extension-port-stream": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/extension-port-stream/-/extension-port-stream-4.2.0.tgz",
+      "integrity": "sha512-i5IgiPVMVrHN+Zx8PRjvFsOw8L1A3sboVwPZghDjW9Yp1BMmBDE6mCcTNu4xMXPYduBOwI3CBK7wd72LcOyD6g==",
+      "license": "ISC",
+      "dependencies": {
+        "readable-stream": "^3.6.2 || ^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "webextension-polyfill": "^0.10.0 || ^0.11.0 || ^0.12.0"
+      }
+    },
+    "node_modules/@xrpl-wallet-adapter/metamask/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@xrpl-wallet-adapter/walletconnect": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@tanstack/react-query": "^5.74.11",
     "@xrpl-wallet-adapter/crossmark": "^0.1.4",
     "@xrpl-wallet-adapter/ledger": "^0.1.0",
+    "@xrpl-wallet-adapter/metamask": "^0.1.2",
     "@xrpl-wallet-adapter/walletconnect": "^0.2.0",
     "@xrpl-wallet-standard/react": "^0.2.4",
     "antd": "^5.24.9",

--- a/src/app/providers.jsx
+++ b/src/app/providers.jsx
@@ -17,7 +17,7 @@ import { WalletProvider as XRPLWalletProvider } from '@xrpl-wallet-standard/reac
 import { CrossmarkWallet } from '@xrpl-wallet-adapter/crossmark';
 import { LedgerWallet } from '@xrpl-wallet-adapter/ledger';
 import { WalletConnectWallet as XRPLWalletConnectWallet } from '@xrpl-wallet-adapter/walletconnect';
-import { MetaMaskWallet } from '@xrpl-wallet-adapter/metamask'
+import { MetaMaskWallet } from '@xrpl-wallet-adapter/metamask';
 
 import { Global } from '@/components/Global';
 import WagmiConfigProvider from '@/lib/provider/WagmiConfigProvider';

--- a/src/app/providers.jsx
+++ b/src/app/providers.jsx
@@ -17,6 +17,7 @@ import { WalletProvider as XRPLWalletProvider } from '@xrpl-wallet-standard/reac
 import { CrossmarkWallet } from '@xrpl-wallet-adapter/crossmark';
 import { LedgerWallet } from '@xrpl-wallet-adapter/ledger';
 import { WalletConnectWallet as XRPLWalletConnectWallet } from '@xrpl-wallet-adapter/walletconnect';
+import { MetaMaskWallet } from '@xrpl-wallet-adapter/metamask'
 
 import { Global } from '@/components/Global';
 import WagmiConfigProvider from '@/lib/provider/WagmiConfigProvider';
@@ -96,6 +97,7 @@ export function Providers({ children }) {
         new CrossmarkWallet(),
         new LedgerWallet(),
         new XRPLWalletConnectWallet(xrplConfig),
+        new MetaMaskWallet(),
       ]);
     }
   }, [rendered, setXRPLlRegisterWallets]);


### PR DESCRIPTION
This change adds the option to pay gas for transactions on XRP Ledger using Metamask, leveraging the [XRPL Snap](https://snaps.metamask.io/snap/npm/xrpl-snap/).

This change was tested on testnet, where I managed to manually pay gas via Metamask for a transaction with a status of "insufficient fee".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds XRPL MetaMask wallet support by installing the adapter and registering MetaMask in the app’s XRPL wallet provider.
> 
> - **XRPL Wallet Integration**:
>   - Register `MetaMaskWallet` in `src/app/providers.jsx` within `XRPLWalletProvider` alongside `CrossmarkWallet`, `LedgerWallet`, and `XRPLWalletConnectWallet`.
> - **Dependencies**:
>   - Add `@xrpl-wallet-adapter/metamask` to `package.json` (lockfile updated).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9773bb33c75bec374dcd5faf92906bbeed084e01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->