### PR TITLE
fix: fix client crashing after paying gas

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -83,8 +83,8 @@ export default function RootLayout({
               <Suspense>{children}</Suspense>
             </Layout>
           </div>
+          <Toaster />
         </Providers>
-        <Toaster />
         <Analytics />
       </body>
     </html>

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { usePathname, useSearchParams } from 'next/navigation';
-import { Suspense, useEffect, useState } from 'react';
+import { Suspense, useEffect, useMemo, useRef, useState } from 'react';
 import { ThemeProvider, useTheme } from 'next-themes';
 // @ts-expect-error — no type declarations available
 import TagManager from 'react-gtm-module';
@@ -26,6 +26,15 @@ import WagmiConfigProvider from '@/lib/provider/WagmiConfigProvider';
 import { queryClient, xrplConfig } from '@/lib/provider/wagmi';
 import * as ga from '@/lib/ga';
 import { ENVIRONMENT } from '@/lib/config';
+
+const { networkConfig: suiNetworkConfig } = createNetworkConfig({
+  testnet: {
+    url: 'https://sui-testnet-rpc.publicnode.com',
+  },
+  mainnet: {
+    url: 'https://sui-rpc.publicnode.com',
+  },
+});
 
 function ThemeWatcher() {
   const { resolvedTheme, setTheme } = useTheme();
@@ -68,53 +77,33 @@ function AnalyticsTracker() {
 }
 
 export function Providers({ children }: { children: React.ReactNode }) {
-  const [rendered, setRendered] = useState(false);
-  const [tagManagerInitiated, setTagManagerInitiated] = useState(false);
-  const [xrplRegisterWallets, setXRPLlRegisterWallets] = useState<
-    XRPLWallet[] | null
-  >(null);
   const [client] = useState(() => queryClient);
-
-  useEffect(() => {
-    setRendered(true);
-  }, []);
+  const tagManagerInitRef = useRef(false);
 
   // google tag manager
   useEffect(() => {
-    if (process.env.NEXT_PUBLIC_GTM_ID && rendered && !tagManagerInitiated) {
+    if (process.env.NEXT_PUBLIC_GTM_ID && !tagManagerInitRef.current) {
+      tagManagerInitRef.current = true;
       TagManager.initialize({ gtmId: process.env.NEXT_PUBLIC_GTM_ID });
-      setTagManagerInitiated(true);
     }
-  }, [rendered, tagManagerInitiated, setTagManagerInitiated]);
-
-  // sui
-  const { networkConfig } = createNetworkConfig({
-    testnet: {
-      url: 'https://sui-testnet-rpc.publicnode.com',
-    },
-    mainnet: {
-      url: 'https://sui-rpc.publicnode.com',
-    },
-  });
+  }, []);
 
   // xrpl - with EIP-6963 support for MetaMask
   const metamaskProvider = useMetaMaskProvider();
-  useEffect(() => {
-    if (!rendered) return;
-
-    const wallets = [
-      new CrossmarkWallet(),
-      new XRPLWalletConnectWallet(
-        xrplConfig as ConstructorParameters<typeof XRPLWalletConnectWallet>[0]
-      ),
-      new XamanWallet(process.env.NEXT_PUBLIC_XAMAN_API_KEY!),
-      new MetaMaskWallet(
-        metamaskProvider as ConstructorParameters<typeof MetaMaskWallet>[0]
-      ),
-    ] as XRPLWallet[];
-
-    setXRPLlRegisterWallets(wallets);
-  }, [rendered, setXRPLlRegisterWallets, metamaskProvider]);
+  const xrplRegisterWallets = useMemo(
+    () =>
+      [
+        new CrossmarkWallet(),
+        new XRPLWalletConnectWallet(
+          xrplConfig as ConstructorParameters<typeof XRPLWalletConnectWallet>[0]
+        ),
+        new XamanWallet(process.env.NEXT_PUBLIC_XAMAN_API_KEY!),
+        new MetaMaskWallet(
+          metamaskProvider as ConstructorParameters<typeof MetaMaskWallet>[0]
+        ),
+      ] as XRPLWallet[],
+    [metamaskProvider]
+  );
 
   return (
     <ThemeProvider
@@ -134,11 +123,11 @@ export function Providers({ children }: { children: React.ReactNode }) {
           <Global />
           <WagmiConfigProvider>
             <XRPLWalletProvider
-              registerWallets={xrplRegisterWallets ?? undefined}
+              registerWallets={xrplRegisterWallets}
               autoConnect={false}
             >
               <SuiClientProvider
-                networks={networkConfig}
+                networks={suiNetworkConfig}
                 defaultNetwork={
                   ENVIRONMENT === 'mainnet' ? 'mainnet' : 'testnet'
                 }

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,31 +1,30 @@
 'use client';
 
-import { usePathname, useSearchParams } from 'next/navigation';
-import { Suspense, useEffect, useMemo, useRef, useState } from 'react';
-import { ThemeProvider, useTheme } from 'next-themes';
-// @ts-expect-error — no type declarations available
-import TagManager from 'react-gtm-module';
-import { IntercomProvider } from 'react-use-intercom';
-import { QueryClientProvider } from '@tanstack/react-query';
-import { useAppKitTheme } from '@reown/appkit/react';
+import { Global } from '@/components/Global.component';
+import { ENVIRONMENT } from '@/lib/config';
+import * as ga from '@/lib/ga';
+import WagmiConfigProvider from '@/lib/provider/WagmiConfigProvider';
+import { queryClient, xrplConfig } from '@/lib/provider/wagmi';
+import { MetaMaskWallet } from '@/lib/wallets/MetaMaskEIP6963Wallet';
+import { useMetaMaskProvider } from '@/lib/wallets/eip6963';
 import {
   createNetworkConfig,
   SuiClientProvider,
   WalletProvider as SuiWalletProvider,
 } from '@mysten/dapp-kit';
-import { WalletProvider as XRPLWalletProvider } from '@xrpl-wallet-standard/react';
-import type { XRPLWallet } from '@xrpl-wallet-standard/core';
+import { useAppKitTheme } from '@reown/appkit/react';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { CrossmarkWallet } from '@xrpl-wallet-adapter/crossmark';
 import { WalletConnectWallet as XRPLWalletConnectWallet } from '@xrpl-wallet-adapter/walletconnect';
 import { XamanWallet } from '@xrpl-wallet-adapter/xaman';
-import { MetaMaskWallet } from '@/lib/wallets/MetaMaskEIP6963Wallet';
-import { useMetaMaskProvider } from '@/lib/wallets/eip6963';
-
-import { Global } from '@/components/Global.component';
-import WagmiConfigProvider from '@/lib/provider/WagmiConfigProvider';
-import { queryClient, xrplConfig } from '@/lib/provider/wagmi';
-import * as ga from '@/lib/ga';
-import { ENVIRONMENT } from '@/lib/config';
+import type { XRPLWallet } from '@xrpl-wallet-standard/core';
+import { WalletProvider as XRPLWalletProvider } from '@xrpl-wallet-standard/react';
+import { ThemeProvider, useTheme } from 'next-themes';
+import { usePathname, useSearchParams } from 'next/navigation';
+import { Suspense, useEffect, useRef, useState } from 'react';
+// @ts-expect-error — no type declarations available
+import TagManager from 'react-gtm-module';
+import { IntercomProvider } from 'react-use-intercom';
 
 const { networkConfig: suiNetworkConfig } = createNetworkConfig({
   testnet: {
@@ -89,21 +88,26 @@ export function Providers({ children }: { children: React.ReactNode }) {
   }, []);
 
   // xrpl - with EIP-6963 support for MetaMask
+  // Wallet adapters are constructed in useEffect to avoid calling third-party
+  // constructors during SSR — they may access browser globals like `window`.
   const metamaskProvider = useMetaMaskProvider();
-  const xrplRegisterWallets = useMemo(
-    () =>
-      [
-        new CrossmarkWallet(),
-        new XRPLWalletConnectWallet(
-          xrplConfig as ConstructorParameters<typeof XRPLWalletConnectWallet>[0]
-        ),
-        new XamanWallet(process.env.NEXT_PUBLIC_XAMAN_API_KEY!),
-        new MetaMaskWallet(
-          metamaskProvider as ConstructorParameters<typeof MetaMaskWallet>[0]
-        ),
-      ] as XRPLWallet[],
-    [metamaskProvider]
-  );
+  const [xrplRegisterWallets, setXrplRegisterWallets] = useState<
+    XRPLWallet[] | undefined
+  >();
+  useEffect(() => {
+    // Wallet adapter constructors may access browser globals; must defer to client via effect.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setXrplRegisterWallets([
+      new CrossmarkWallet(),
+      new XRPLWalletConnectWallet(
+        xrplConfig as ConstructorParameters<typeof XRPLWalletConnectWallet>[0]
+      ),
+      new XamanWallet(process.env.NEXT_PUBLIC_XAMAN_API_KEY!),
+      new MetaMaskWallet(
+        metamaskProvider as ConstructorParameters<typeof MetaMaskWallet>[0]
+      ),
+    ] as XRPLWallet[]);
+  }, [metamaskProvider]);
 
   return (
     <ThemeProvider

--- a/src/components/NonSSRWrapper.tsx
+++ b/src/components/NonSSRWrapper.tsx
@@ -1,8 +1,0 @@
-import dynamic from 'next/dynamic';
-import React, { type ReactNode } from 'react';
-
-const NonSSRWrapper = (props: { children: ReactNode }) => (
-  <React.Fragment>{props.children}</React.Fragment>
-);
-
-export default dynamic(() => Promise.resolve(NonSSRWrapper), { ssr: false });

--- a/src/lib/provider/WagmiConfigProvider.tsx
+++ b/src/lib/provider/WagmiConfigProvider.tsx
@@ -1,16 +1,34 @@
+'use client';
+
+import { useSyncExternalStore, type ReactNode } from 'react';
 import { WagmiProvider } from 'wagmi';
 
-import NonSSRWrapper from '@/components/NonSSRWrapper';
 import { wagmiConfig } from '@/lib/provider/wagmi';
 
+const emptySubscribe = () => () => {};
+const getClientSnapshot = () => true;
+const getServerSnapshot = () => false;
+
+// Client-only: wagmi and its dependencies
+// reference browser globals like `window` at module scope, so WagmiProvider
+// cannot render during SSR. We defer with useSyncExternalStore instead of
+// next/dynamic({ ssr: false }) because dynamic() wraps children in a
+// React.lazy Suspense boundary, which can cause downstream hooks (wagmi,
+// @mysten/dapp-kit) to lose the QueryClientProvider context during
+// concurrent re-renders — surfacing as errors after
+// wallet transactions.
 export default function WagmiConfigProvider({
   children,
 }: {
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
-  return (
-    <NonSSRWrapper>
-      <WagmiProvider config={wagmiConfig}>{children}</WagmiProvider>
-    </NonSSRWrapper>
+  const mounted = useSyncExternalStore(
+    emptySubscribe,
+    getClientSnapshot,
+    getServerSnapshot
   );
+
+  if (!mounted) return null;
+
+  return <WagmiProvider config={wagmiConfig}>{children}</WagmiProvider>;
 }


### PR DESCRIPTION
**Description**

- Rearrange the Providers flow to avoid crashing.
- Change `WagmiConfigProvider` to use `use client` with a `mounted` check, instead of  `NonSSRWrapper`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the app’s top-level provider composition and client/SSR gating for wagmi and wallet adapters; mistakes here can cause subtle hydration or wallet-connection regressions across chains.
> 
> **Overview**
> Fixes a client crash after wallet transactions by restructuring provider initialization to be *strictly client-only* and more stable under concurrent re-renders.
> 
> `WagmiConfigProvider` now gates rendering with a `useSyncExternalStore` “mounted” check (instead of `next/dynamic` via the removed `NonSSRWrapper`) to avoid SSR `window` access and preserve `QueryClientProvider` context for downstream wallet hooks. `Providers` also moves GTM init to a `useRef` guard, hoists Sui `createNetworkConfig`, and constructs XRPL wallet adapters in an effect so third-party constructors don’t run during SSR. `Toaster` is moved inside `Providers` in `layout.tsx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b62a2b1d7a4e9563d5e69b8fc7b1112e2e2001c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->