### PR TITLE
feat: integrate Intercom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@creit.tech/stellar-wallets-kit": "^1.9.5",
         "@headlessui/react": "^2.2.2",
         "@headlessui/tailwindcss": "^0.2.2",
+        "@intercom/messenger-js-sdk": "^0.0.19",
         "@mysten/dapp-kit": "^0.16.1",
         "@mysten/sui": "^1.29.0",
         "@nivo/sankey": "^0.92.2",
@@ -4027,6 +4028,12 @@
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
+    },
+    "node_modules/@intercom/messenger-js-sdk": {
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@intercom/messenger-js-sdk/-/messenger-js-sdk-0.0.19.tgz",
+      "integrity": "sha512-ZpzJXLyo4VReQoOW/OOCYZqylhg2uwj0RGU6pcYazFDuk/S1Xsqi0GChLQMDviBQ/SuKB1Mv50uFsY7KzHljGw==",
+      "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
         "react-hot-toast": "^2.5.2",
         "react-icons": "^5.5.0",
         "react-linkify": "^1.0.0-alpha",
-        "react-use-intercom": "^5.4.3",
         "react18-json-view": "^0.2.9",
         "recharts": "^2.15.3",
         "tailwindcss": "^3.4.17",
@@ -27912,15 +27911,6 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
-      }
-    },
-    "node_modules/react-use-intercom": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/react-use-intercom/-/react-use-intercom-5.4.3.tgz",
-      "integrity": "sha512-evTgJWzBB+0G3lb8PKQlWIRub/VyfaJrNAgSb3HpCq6EQjI12r0F2kriUkE2EWbbj7HSA05SG+weA0Hb+kzq1g==",
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/react18-json-view": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "react-hot-toast": "^2.5.2",
     "react-icons": "^5.5.0",
     "react-linkify": "^1.0.0-alpha",
-    "react-use-intercom": "^5.4.3",
     "react18-json-view": "^0.2.9",
     "recharts": "^2.15.3",
     "tailwindcss": "^3.4.17",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@creit.tech/stellar-wallets-kit": "^1.9.5",
     "@headlessui/react": "^2.2.2",
     "@headlessui/tailwindcss": "^0.2.2",
+    "@intercom/messenger-js-sdk": "^0.0.19",
     "@mysten/dapp-kit": "^0.16.1",
     "@mysten/sui": "^1.29.0",
     "@nivo/sankey": "^0.92.2",

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -24,7 +24,7 @@ import { usePathname, useSearchParams } from 'next/navigation';
 import { Suspense, useEffect, useRef, useState } from 'react';
 // @ts-expect-error — no type declarations available
 import TagManager from 'react-gtm-module';
-import { IntercomProvider } from 'react-use-intercom';
+import { IntercomChat } from '@/components/IntercomChat';
 
 const { networkConfig: suiNetworkConfig } = createNetworkConfig({
   testnet: {
@@ -115,10 +115,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
       disableTransitionOnChange
       enableColorScheme={false}
     >
-      <IntercomProvider
-        appId={process.env.NEXT_PUBLIC_INTERCOM_APP_ID!}
-        autoBoot={true}
-      >
+        <IntercomChat />
         <ThemeWatcher />
         <Suspense>
           <AnalyticsTracker />
@@ -141,7 +138,6 @@ export function Providers({ children }: { children: React.ReactNode }) {
             </XRPLWalletProvider>
           </WagmiConfigProvider>
         </QueryClientProvider>
-      </IntercomProvider>
     </ThemeProvider>
   );
 }

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -115,29 +115,27 @@ export function Providers({ children }: { children: React.ReactNode }) {
       disableTransitionOnChange
       enableColorScheme={false}
     >
-        <IntercomChat />
-        <ThemeWatcher />
-        <Suspense>
-          <AnalyticsTracker />
-        </Suspense>
-        <QueryClientProvider client={client}>
-          <Global />
-          <WagmiConfigProvider>
-            <XRPLWalletProvider
-              registerWallets={xrplRegisterWallets}
-              autoConnect={false}
+      <IntercomChat />
+      <ThemeWatcher />
+      <Suspense>
+        <AnalyticsTracker />
+      </Suspense>
+      <QueryClientProvider client={client}>
+        <Global />
+        <WagmiConfigProvider>
+          <XRPLWalletProvider
+            registerWallets={xrplRegisterWallets}
+            autoConnect={false}
+          >
+            <SuiClientProvider
+              networks={suiNetworkConfig}
+              defaultNetwork={ENVIRONMENT === 'mainnet' ? 'mainnet' : 'testnet'}
             >
-              <SuiClientProvider
-                networks={suiNetworkConfig}
-                defaultNetwork={
-                  ENVIRONMENT === 'mainnet' ? 'mainnet' : 'testnet'
-                }
-              >
-                <SuiWalletProvider>{children}</SuiWalletProvider>
-              </SuiClientProvider>
-            </XRPLWalletProvider>
-          </WagmiConfigProvider>
-        </QueryClientProvider>
+              <SuiWalletProvider>{children}</SuiWalletProvider>
+            </SuiClientProvider>
+          </XRPLWalletProvider>
+        </WagmiConfigProvider>
+      </QueryClientProvider>
     </ThemeProvider>
   );
 }

--- a/src/components/IntercomChat/IntercomChat.component.tsx
+++ b/src/components/IntercomChat/IntercomChat.component.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import { useIntercomChat } from './IntercomChat.hooks';
+
+/** Boots the Intercom messenger and syncs the active transaction hash for Fin AI. */
+export function IntercomChat() {
+  useIntercomChat(process.env.NEXT_PUBLIC_INTERCOM_APP_ID);
+  return null;
+}

--- a/src/components/IntercomChat/IntercomChat.hooks.ts
+++ b/src/components/IntercomChat/IntercomChat.hooks.ts
@@ -27,16 +27,6 @@ function getMessenger(): ((...args: unknown[]) => void) | undefined {
 }
 
 /**
- * Resolves the tx identifier to surface to Fin AI.
- * Only set when the user is on a /gmp/ or /transactions/ detail page.
- * Reads window.location.pathname directly so it is always current, even
- * when called from a long-lived closure such as an onShow handler.
- */
-function resolveLatestTxHash(): string {
-  return extractTxFromPathname(window.location.pathname) ?? '';
-}
-
-/**
  * Boots the Intercom messenger and keeps latest_swap_tx_hash in sync with
  * the currently viewed transaction page so Fin AI can look it up without
  * asking the user.
@@ -46,19 +36,22 @@ export function useIntercomChat(appId: string | undefined): void {
 
   // Boot once on mount with the active tx hash already set so Fin never
   // reads a stale value from the anonymous visitor cookie.
-  // onShow is registered here (once) so it never captures a stale closure.
+  // onShow is registered here (once) so it never captures a stale pathname
+  // closure — window.location.pathname is read at call time instead.
   useEffect(() => {
     if (!appId) return;
     Intercom({
       app_id: appId,
       api_base: INTERCOM_API_BASE,
-      latest_swap_tx_hash: resolveLatestTxHash(),
+      latest_swap_tx_hash:
+        extractTxFromPathname(window.location.pathname) ?? '',
       axelar_environment: ENVIRONMENT,
     });
 
     getMessenger()?.('onShow', () => {
       getMessenger()?.('update', {
-        latest_swap_tx_hash: resolveLatestTxHash(),
+        latest_swap_tx_hash:
+          extractTxFromPathname(window.location.pathname) ?? '',
       });
     });
   }, [appId]);
@@ -68,7 +61,7 @@ export function useIntercomChat(appId: string | undefined): void {
     if (!appId) return;
     getMessenger()?.('update', {
       current_page_path: pathname,
-      latest_swap_tx_hash: resolveLatestTxHash(),
+      latest_swap_tx_hash: extractTxFromPathname(pathname) ?? '',
     });
   }, [appId, pathname]);
 }

--- a/src/components/IntercomChat/IntercomChat.hooks.ts
+++ b/src/components/IntercomChat/IntercomChat.hooks.ts
@@ -20,7 +20,9 @@ function extractTxFromPathname(pathname: string): string | null {
 
 /** Returns the Intercom messenger function, or undefined if not yet initialised. */
 function getMessenger(): ((...args: unknown[]) => void) | undefined {
-  const messenger = (window as unknown as { Intercom?: (...args: unknown[]) => void }).Intercom;
+  const messenger = (
+    window as unknown as { Intercom?: (...args: unknown[]) => void }
+  ).Intercom;
   return typeof messenger === 'function' ? messenger : undefined;
 }
 
@@ -57,7 +59,9 @@ export function useIntercomChat(appId: string | undefined): void {
     });
 
     getMessenger()?.('onShow', () => {
-      getMessenger()?.('update', { latest_swap_tx_hash: resolveLatestTxHash() });
+      getMessenger()?.('update', {
+        latest_swap_tx_hash: resolveLatestTxHash(),
+      });
     });
   }, [appId]);
 

--- a/src/components/IntercomChat/IntercomChat.hooks.ts
+++ b/src/components/IntercomChat/IntercomChat.hooks.ts
@@ -1,0 +1,72 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+import Intercom from '@intercom/messenger-js-sdk';
+import { ENVIRONMENT } from '@/lib/config';
+
+const INTERCOM_API_BASE = 'https://api-iam.intercom.io';
+
+/**
+ * Extracts the transaction identifier from GMP or transaction detail URLs.
+ * Matches /gmp/<tx> and /transactions/<tx>.
+ * Preserves the full identifier including any log-index suffix (e.g. 0xabc...-1)
+ * so the data connector can resolve it as a messageId.
+ */
+function extractTxFromPathname(pathname: string): string | null {
+  const match = pathname.match(/^\/(?:gmp|transactions)\/(.+)$/);
+  return match?.[1] ?? null;
+}
+
+/** Returns the Intercom messenger function, or undefined if not yet initialised. */
+function getMessenger(): ((...args: unknown[]) => void) | undefined {
+  const messenger = (window as unknown as { Intercom?: (...args: unknown[]) => void }).Intercom;
+  return typeof messenger === 'function' ? messenger : undefined;
+}
+
+/**
+ * Resolves the tx identifier to surface to Fin AI.
+ * Only set when the user is on a /gmp/ or /transactions/ detail page.
+ * Reads window.location.pathname directly so it is always current, even
+ * when called from a long-lived closure such as an onShow handler.
+ */
+function resolveLatestTxHash(): string {
+  const tx = extractTxFromPathname(window.location.pathname);
+  console.log('[Intercom] latest_swap_tx_hash:', tx ?? '(empty)');
+  return tx ?? '';
+}
+
+/**
+ * Boots the Intercom messenger and keeps latest_swap_tx_hash in sync with
+ * the currently viewed transaction page so Fin AI can look it up without
+ * asking the user.
+ */
+export function useIntercomChat(appId: string | undefined): void {
+  const pathname = usePathname();
+
+  // Boot once on mount with the active tx hash already set so Fin never
+  // reads a stale value from the anonymous visitor cookie.
+  // onShow is registered here (once) so it never captures a stale closure.
+  useEffect(() => {
+    if (!appId) return;
+    Intercom({
+      app_id: appId,
+      api_base: INTERCOM_API_BASE,
+      latest_swap_tx_hash: resolveLatestTxHash(),
+      axelar_environment: ENVIRONMENT,
+    });
+
+    getMessenger()?.('onShow', () => {
+      getMessenger()?.('update', { latest_swap_tx_hash: resolveLatestTxHash() });
+    });
+  }, [appId]);
+
+  // On every route change, update the current path and active tx hash.
+  useEffect(() => {
+    if (!appId) return;
+    getMessenger()?.('update', {
+      current_page_path: pathname,
+      latest_swap_tx_hash: resolveLatestTxHash(),
+    });
+  }, [appId, pathname]);
+}

--- a/src/components/IntercomChat/IntercomChat.hooks.ts
+++ b/src/components/IntercomChat/IntercomChat.hooks.ts
@@ -46,6 +46,7 @@ export function useIntercomChat(appId: string | undefined): void {
       latest_swap_tx_hash:
         extractTxFromPathname(window.location.pathname) ?? '',
       axelar_environment: ENVIRONMENT,
+      axelar_app: 'axelarscan',
     });
 
     getMessenger()?.('onShow', () => {

--- a/src/components/IntercomChat/IntercomChat.hooks.ts
+++ b/src/components/IntercomChat/IntercomChat.hooks.ts
@@ -33,9 +33,7 @@ function getMessenger(): ((...args: unknown[]) => void) | undefined {
  * when called from a long-lived closure such as an onShow handler.
  */
 function resolveLatestTxHash(): string {
-  const tx = extractTxFromPathname(window.location.pathname);
-  console.log('[Intercom] latest_swap_tx_hash:', tx ?? '(empty)');
-  return tx ?? '';
+  return extractTxFromPathname(window.location.pathname) ?? '';
 }
 
 /**

--- a/src/components/IntercomChat/IntercomChat.hooks.ts
+++ b/src/components/IntercomChat/IntercomChat.hooks.ts
@@ -53,6 +53,7 @@ export function useIntercomChat(appId: string | undefined): void {
       getMessenger()?.('update', {
         latest_swap_tx_hash:
           extractTxFromPathname(window.location.pathname) ?? '',
+        axelar_app: 'axelarscan',
       });
     });
   }, [appId]);

--- a/src/components/IntercomChat/index.ts
+++ b/src/components/IntercomChat/index.ts
@@ -1,0 +1,1 @@
+export { IntercomChat } from './IntercomChat.component';

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,3 +9,9 @@
 .ant-btn-primary {
   @apply !bg-blue-600 !text-white;
 }
+
+.intercom-lightweight-app,
+.intercom-app,
+#intercom-container {
+  z-index: 40 !important;
+}


### PR DESCRIPTION
Integrates Intercom Messenger through the intercomChat component which:
  - Boots Intercom with `latest_swap_tx_hash` already set at mount, so Fin AI can
    look up a transaction without prompting the user
  - Extracts the transaction identifier from `/gmp/[tx]` and `/transactions/[tx]`
    URLs, preserving the full message ID including log-index suffix
    (e.g. `0xabc..._0_14`) for correct data connector resolution
  - Registers an `onShow` handler once at boot that reads `window.location` at call
    time, avoiding stale closure issues across navigations
  - Passes `axelar_environment` so Fin can route to the correct mainnet or testnet
    data connector
  - Sets Intercom launcher z-index to 40 via CSS, placing it below filter dropdowns
    (`z-50`) and level with the header (`z-40`)