### PR TITLE
feat: Intercom messenger navbar-ceiling CSS

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,7 @@ import { Layout } from '@/components/Layout';
 
 import '@/styles/tailwind.css';
 import '@/styles/global.css';
+import '@/styles/intercom.css';
 
 export const metadata: Metadata = {
   title: {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,4 +9,3 @@
 .ant-btn-primary {
   @apply !bg-blue-600 !text-white;
 }
-

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -10,8 +10,3 @@
   @apply !bg-blue-600 !text-white;
 }
 
-.intercom-lightweight-app,
-.intercom-app,
-#intercom-container {
-  z-index: 40 !important;
-}

--- a/src/styles/intercom.css
+++ b/src/styles/intercom.css
@@ -1,0 +1,23 @@
+/* Intercom: sit below the navbar on desktop, above it on mobile (full-screen). */
+.intercom-lightweight-app,
+.intercom-app,
+#intercom-container {
+  z-index: 40 !important;
+}
+
+/* Desktop: navbar is 88px; panel bottom-offset is ~80px — clamp height so it can't overlap. */
+@media (min-width: 768px) {
+  .intercom-app .intercom-messenger-frame,
+  iframe[name="intercom-messenger-frame"] {
+    max-height: calc(100dvh - 168px) !important;
+  }
+}
+
+/* Mobile: raise above the navbar (z-50) so the full-screen messenger covers it. */
+@media (max-width: 767px) {
+  .intercom-lightweight-app,
+  .intercom-app,
+  #intercom-container {
+    z-index: 60 !important;
+  }
+}

--- a/src/styles/intercom.css
+++ b/src/styles/intercom.css
@@ -8,7 +8,7 @@
 /* Desktop: navbar is 88px; panel bottom-offset is ~80px — clamp height so it can't overlap. */
 @media (min-width: 768px) {
   .intercom-app .intercom-messenger-frame,
-  iframe[name="intercom-messenger-frame"] {
+  iframe[name='intercom-messenger-frame'] {
     max-height: calc(100dvh - 168px) !important;
   }
 }


### PR DESCRIPTION
## Summary

- Moves the Intercom z-index override out of `global.css` into a dedicated `src/styles/intercom.css`
- Desktop (≥768px): clamps `max-height` on the messenger panel so it can't grow above the 88px navbar
- Mobile (<768px): raises the Intercom container z-index above the navbar (`z-50` → `z-60`) so the full-screen messenger covers it naturally, without any position constraints

## Test plan

- [ ] Desktop: open the Intercom messenger and verify the panel top does not overlap the navbar
- [ ] Mobile: open the Intercom messenger and verify it opens full-screen, covering the navbar, with the text input visible