### PR TITLE
fix: hide Intercom launcher when a dialog or sidebar is open

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,7 @@ import { Layout } from '@/components/Layout';
 
 import '@/styles/tailwind.css';
 import '@/styles/global.css';
+import '@/styles/intercom.css';
 
 export const metadata: Metadata = {
   title: {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,4 +9,3 @@
 .ant-btn-primary {
   @apply !bg-blue-600 !text-white;
 }
-

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -10,8 +10,3 @@
   @apply !bg-blue-600 !text-white;
 }
 
-.intercom-lightweight-app,
-.intercom-app,
-#intercom-container {
-  z-index: 40 !important;
-}

--- a/src/styles/intercom.css
+++ b/src/styles/intercom.css
@@ -1,0 +1,23 @@
+/* Intercom: sit below the navbar on desktop, above it on mobile (full-screen). */
+.intercom-lightweight-app,
+.intercom-app,
+#intercom-container {
+  z-index: 40 !important;
+}
+
+/* Desktop: navbar is 88px; panel bottom-offset is ~80px — clamp height so it can't overlap. */
+@media (min-width: 768px) {
+  .intercom-app .intercom-messenger-frame,
+  iframe[name="intercom-messenger-frame"] {
+    max-height: calc(100dvh - 168px) !important;
+  }
+}
+
+/* Mobile: raise above the navbar (z-50) so the full-screen messenger covers it. */
+@media (max-width: 767px) {
+  .intercom-lightweight-app,
+  .intercom-app,
+  #intercom-container {
+    z-index: 60 !important;
+  }
+}

--- a/src/styles/intercom.css
+++ b/src/styles/intercom.css
@@ -21,3 +21,10 @@
     z-index: 60 !important;
   }
 }
+
+/* Hide the launcher when any dialog/sidebar is open (e.g. filter panel). */
+body:has([role="dialog"]) .intercom-lightweight-app,
+body:has([role="dialog"]) .intercom-app,
+body:has([role="dialog"]) #intercom-container {
+  display: none !important;
+}

--- a/src/styles/intercom.css
+++ b/src/styles/intercom.css
@@ -8,7 +8,7 @@
 /* Desktop: navbar is 88px; panel bottom-offset is ~80px — clamp height so it can't overlap. */
 @media (min-width: 768px) {
   .intercom-app .intercom-messenger-frame,
-  iframe[name="intercom-messenger-frame"] {
+  iframe[name='intercom-messenger-frame'] {
     max-height: calc(100dvh - 168px) !important;
   }
 }


### PR DESCRIPTION
The messenger bubble now disappears when a dialog or sidebar is open to prevent overlapping issues on mobile. Also moved the .css config in a separate file.