### PR TITLE
fix: hide Intercom launcher when a dialog or sidebar is open

### DIFF
--- a/src/styles/intercom.css
+++ b/src/styles/intercom.css
@@ -23,8 +23,8 @@
 }
 
 /* Hide the launcher when any dialog/sidebar is open (e.g. filter panel). */
-body:has([role="dialog"]) .intercom-lightweight-app,
-body:has([role="dialog"]) .intercom-app,
-body:has([role="dialog"]) #intercom-container {
+body:has([role='dialog']) .intercom-lightweight-app,
+body:has([role='dialog']) .intercom-app,
+body:has([role='dialog']) #intercom-container {
   display: none !important;
 }

--- a/src/styles/intercom.css
+++ b/src/styles/intercom.css
@@ -21,3 +21,10 @@
     z-index: 60 !important;
   }
 }
+
+/* Hide the launcher when any dialog/sidebar is open (e.g. filter panel). */
+body:has([role="dialog"]) .intercom-lightweight-app,
+body:has([role="dialog"]) .intercom-app,
+body:has([role="dialog"]) #intercom-container {
+  display: none !important;
+}


### PR DESCRIPTION
The messenger bubble now disappears when a dialog or sidebar is open to prevent overlapping issues on mobile.