### PR TITLE
fix: stop showing Add Gas button on funded messages waiting for finality

### DIFF
--- a/src/components/GMP/Info/RecoveryButtons.utils.test.ts
+++ b/src/components/GMP/Info/RecoveryButtons.utils.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @jest-environment node
+ */
+// Avoid pulling the @/components/GMPs barrel (which transitively imports image
+// assets Jest can't transform). RecoveryButtons.utils only uses
+// checkNeedMoreGasFromError from it, and these fixtures never set an error.
+jest.mock('@/components/GMPs', () => ({
+  checkNeedMoreGasFromError: () => false,
+}));
+
+import { shouldShowAddGasButton } from './RecoveryButtons.utils';
+import type { ChainMetadata, GMPMessage } from '../GMP.types';
+
+// Minimal chain metadata so getChainData() resolves the source chain.
+const chains = [{ id: 'ethereum', chain_id: 1 }] as unknown as ChainMetadata[];
+
+// A message that has paid gas and is sitting in the "Waiting for Finality"
+// stage (no confirm/approved/executed yet) on an EVM source chain.
+const createMessage = (overrides?: Partial<GMPMessage>): GMPMessage => ({
+  call: {
+    chain: 'ethereum',
+    chain_type: 'evm',
+    destination_chain_type: 'evm',
+    transactionHash: '0xtx',
+    logIndex: 1,
+    eventIndex: 2,
+    message_id: 'message-id',
+  },
+  gas_paid: {} as GMPMessage['gas_paid'],
+  ...overrides,
+});
+
+describe('shouldShowAddGasButton — Waiting for Finality (MEL-48)', () => {
+  it('does NOT show Add Gas when gas is paid and only gas_remain_amount is near zero', () => {
+    // Regression: a correctly funded message can legitimately have ~0 gas
+    // remaining (no refund expected) while waiting for finality. The old
+    // gas_remain_amount < 0.000001 heuristic surfaced the button here even
+    // though the transaction goes on to complete normally.
+    const data = createMessage({
+      gas: { gas_remain_amount: 0 } as GMPMessage['gas'],
+    });
+
+    expect(shouldShowAddGasButton(data, null, chains)).toBe(false);
+  });
+
+  it('still shows Add Gas when no gas was paid', () => {
+    const data = createMessage({ gas_paid: undefined });
+
+    expect(shouldShowAddGasButton(data, null, chains)).toBe(true);
+  });
+
+  it('still shows Add Gas when the backend flags an insufficient fee', () => {
+    const data = createMessage({
+      gas: { gas_remain_amount: 0 } as GMPMessage['gas'],
+      is_insufficient_fee: true,
+    });
+
+    expect(shouldShowAddGasButton(data, null, chains)).toBe(true);
+  });
+
+  it('still shows Add Gas when the backend flags invalid gas paid', () => {
+    const data = createMessage({
+      gas: { gas_remain_amount: 0 } as GMPMessage['gas'],
+      is_invalid_gas_paid: true,
+    });
+
+    expect(shouldShowAddGasButton(data, null, chains)).toBe(true);
+  });
+
+  it('still shows Add Gas when the backend flags not enough gas to execute', () => {
+    const data = createMessage({
+      gas: { gas_remain_amount: 0 } as GMPMessage['gas'],
+      not_enough_gas_to_execute: true,
+    });
+
+    expect(shouldShowAddGasButton(data, null, chains)).toBe(true);
+  });
+});

--- a/src/components/GMP/Info/RecoveryButtons.utils.ts
+++ b/src/components/GMP/Info/RecoveryButtons.utils.ts
@@ -76,7 +76,7 @@ function isChainSupportedForAddGas(
  * other recovery paths require it (e.g. callback leg).
  */
 function needsGasForOriginalCall(gmp: GMPMessage): boolean {
-  const { call, gas_paid, confirm, approved, executed, gas } = gmp;
+  const { call, gas_paid, confirm, approved, executed } = gmp;
 
   // If the message is already executed (or marked executed) we do not need more gas.
   if (executed || gmp.is_executed || approved) {
@@ -97,14 +97,20 @@ function needsGasForOriginalCall(gmp: GMPMessage): boolean {
     return false;
   }
 
-  // Detect insufficient gas using Axelar-provided flags and balances.
+  // Detect insufficient gas using Axelar-provided flags only.
   // Any of these markers signal that the origin leg still needs funding.
+  //
+  // NOTE: We intentionally do NOT infer a shortage from `gas.gas_remain_amount`
+  // being near zero. A correctly funded message can legitimately have ~0 gas
+  // remaining (no refund expected) while it is still "Waiting for Finality",
+  // which produced false-positive Add Gas buttons on transactions that go on to
+  // complete normally. Genuine shortages are already reported by the backend via
+  // `is_insufficient_fee` / `is_invalid_gas_paid` / `not_enough_gas_to_execute`.
   const shortageDetected =
     !(gas_paid || gmp.gas_paid_to_callback) ||
     gmp.is_insufficient_fee ||
     gmp.is_invalid_gas_paid ||
-    gmp.not_enough_gas_to_execute ||
-    (gas?.gas_remain_amount !== undefined && gas.gas_remain_amount < 0.000001);
+    gmp.not_enough_gas_to_execute;
 
   return shortageDetected;
 }


### PR DESCRIPTION
## Problem

The "Add Gas" / Recover button was shown on GMP transactions that were correctly funded and still sitting in the "Waiting for Finality" stage, even though those transactions go on to complete normally. This created false-positive prompts for users to add gas they did not need.

## Root cause

`needsGasForOriginalCall()` in `RecoveryButtons.utils.ts` inferred a gas shortage from a hardcoded heuristic:

```ts
gas?.gas_remain_amount !== undefined && gas.gas_remain_amount < 0.000001
```

`gas_remain_amount` is clamped to `>= 0` by the GMP indexer, so this check fires precisely when `paid ≈ base_fee`, which is a perfectly normal state for an in-flight message (no refund is expected). A near-zero remaining balance does not mean the message is underfunded.

## Fix

Remove the `gas_remain_amount` dust check and rely only on the backend's dedicated shortage signals, which already cover the genuine cases:

- `!gas_paid` (no gas paid at all)
- `is_insufficient_fee` (paid less than the Axelar base fee)
- `is_invalid_gas_paid`
- `not_enough_gas_to_execute` (set by the relayer after it attempts/estimates execution, post-finality)

These flags are computed server-side in the GMP indexer (`setGasData.js` / `setBaseFees.js`), so the UI does not need its own balance heuristic on top of them. Note that `is_insufficient_fee` reflects the Axelar network base fee only and does not include destination execution gas, which is why a funded message can legitimately show near-zero remaining while still completing.

## Tests

Adds `RecoveryButtons.utils.test.ts`:

- Does NOT show Add Gas for a funded message with `gas_remain_amount = 0` (the regression).
- Still shows Add Gas when no gas was paid.
- Still shows Add Gas for each genuine-shortage flag (`is_insufficient_fee`, `is_invalid_gas_paid`, `not_enough_gas_to_execute`).

Full suite: 7 suites, 324 tests pass locally (`npx jest`). Prettier and ESLint clean on the changed files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow GMP recovery-button logic change; real underfunding paths still use existing indexer flags.
> 
> **Overview**
> Stops surfacing the **Add Gas** recovery action when a GMP message is already funded and only shows a near-zero `gas_remain_amount` while still in **Waiting for Finality**.
> 
> In `needsGasForOriginalCall`, the UI no longer treats `gas.gas_remain_amount < 0.000001` as a shortage. **Add Gas** now depends on backend shortage signals only: missing `gas_paid`, `is_insufficient_fee`, `is_invalid_gas_paid`, and `not_enough_gas_to_execute`. A short comment documents why the balance dust check was removed.
> 
> Adds `RecoveryButtons.utils.test.ts` with a Jest mock to avoid the GMPs barrel, covering the regression (paid gas + `gas_remain_amount: 0` → no button) and that genuine shortage flags still show the button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54e9635ce40d8f78324dc5137d0509c0b6b3c190. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->