### PR TITLE
feat: show cosmos IBC channels on resources/chains

### DIFF
--- a/src/components/Resources/Chain.component.tsx
+++ b/src/components/Resources/Chain.component.tsx
@@ -50,9 +50,13 @@ export function Chain({ data }: ChainProps) {
     explorer,
     prefix_address,
     chain_type,
+    ibc,
   } = { ...data };
   const { rpc, lcd } = { ...endpoints };
   const { url, address_path } = { ...explorer };
+
+  const outboundChannelId = ibc?.fromAxelar?.channelId;
+  const inboundChannelId = ibc?.toAxelar?.channelId;
 
   const gatewayAddress =
     data?.gateway?.address || gateway_contracts?.[id]?.address;
@@ -209,6 +213,20 @@ export function Chain({ data }: ChainProps) {
           )}
           {prefix_address && (
             <ValueBox title="Address Prefix" value={prefix_address} />
+          )}
+          {outboundChannelId && (
+            <ValueBox
+              title="Outbound IBC Channel (from Axelar)"
+              value={outboundChannelId}
+              noEllipse={true}
+            />
+          )}
+          {inboundChannelId && (
+            <ValueBox
+              title="Inbound IBC Channel (to Axelar)"
+              value={inboundChannelId}
+              noEllipse={true}
+            />
           )}
         </div>
       </div>

--- a/src/components/Resources/Resources.types.ts
+++ b/src/components/Resources/Resources.types.ts
@@ -54,6 +54,16 @@ export interface ContractRef {
   [key: string]: unknown;
 }
 
+export interface IBCChannelEnd {
+  portId?: string;
+  channelId?: string;
+}
+
+export interface IBCChannels {
+  fromAxelar?: IBCChannelEnd;
+  toAxelar?: IBCChannelEnd;
+}
+
 export type ChainResourceData = Chain & {
   gateway?: ContractRef;
   multisig_prover?: ContractRef;
@@ -62,6 +72,7 @@ export type ChainResourceData = Chain & {
   service_registry?: ContractRef;
   rewards?: ContractRef;
   multisig?: ContractRef;
+  ibc?: IBCChannels;
 };
 
 export interface AssetAddressEntry {


### PR DESCRIPTION
Display the inbound (to Axelar) and outbound (from Axelar) IBC channel ids for cosmos chains on the chains resource cards, sourced from the enriched getChains API response.

Companion PR to https://github.com/axelarnetwork/axelarscan-api/pull/341

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only UI and type additions; no auth, routing, or data mutation—missing `ibc` data simply omits the new fields.
> 
> **Overview**
> Chain resource cards now surface **IBC channel IDs** from the enriched `getChains` payload when present.
> 
> `ChainResourceData` gains optional `ibc` typing (`fromAxelar` / `toAxelar` with `channelId` and `portId`). The chain card reads `ibc.fromAxelar.channelId` and `ibc.toAxelar.channelId` and renders two conditional `ValueBox` rows—**Outbound IBC Channel (from Axelar)** and **Inbound IBC Channel (to Axelar)**—with full-width display (`noEllipse`), alongside existing endpoint and address fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 083e547f731350ce9cf600024c9180733e8c871f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->