### PR TITLE
chore: properly mark non-bridgable chains and assets

### DIFF
--- a/src/components/NetworkGraph/NetworkGraph.component.tsx
+++ b/src/components/NetworkGraph/NetworkGraph.component.tsx
@@ -9,7 +9,7 @@ import _ from 'lodash';
 
 import { Spinner } from '@/components/Spinner';
 import { useChains } from '@/hooks/useGlobalData';
-import { getChainData } from '@/lib/config';
+import { getChainData, makeDeprecatedChainChecker } from '@/lib/config';
 import { toArray } from '@/lib/parser';
 import { equalsIgnoreCase, find } from '@/lib/string';
 
@@ -21,12 +21,7 @@ import type {
   GraphEdge,
   GraphData,
 } from './NetworkGraph.types';
-import {
-  TIERS,
-  THRESHOLD,
-  getDeprecatedChainIds,
-  isDeprecatedChain,
-} from './NetworkGraph.utils';
+import { TIERS, THRESHOLD } from './NetworkGraph.utils';
 import {
   useImagePreloader,
   useNodeCanvasObject,
@@ -55,12 +50,12 @@ export function NetworkGraph({
   }, []);
 
   const activeData = useMemo(() => {
-    const deprecatedChainIds = getDeprecatedChainIds(chains);
+    const isDeprecatedChain = makeDeprecatedChainChecker(chains);
 
     return (toArray(data) as NetworkDataItem[]).filter(
       d =>
-        !isDeprecatedChain(d.sourceChain, deprecatedChainIds) &&
-        !isDeprecatedChain(d.destinationChain, deprecatedChainIds)
+        !isDeprecatedChain(d.sourceChain) &&
+        !isDeprecatedChain(d.destinationChain)
     );
   }, [data, chains]);
 

--- a/src/components/NetworkGraph/NetworkGraph.component.tsx
+++ b/src/components/NetworkGraph/NetworkGraph.component.tsx
@@ -21,7 +21,12 @@ import type {
   GraphEdge,
   GraphData,
 } from './NetworkGraph.types';
-import { TIERS, THRESHOLD } from './NetworkGraph.utils';
+import {
+  TIERS,
+  THRESHOLD,
+  getDeprecatedChainIds,
+  isDeprecatedChain,
+} from './NetworkGraph.utils';
 import {
   useImagePreloader,
   useNodeCanvasObject,
@@ -49,6 +54,16 @@ export function NetworkGraph({
     fg?.d3Force('center')?.strength(0);
   }, []);
 
+  const activeData = useMemo(() => {
+    const deprecatedChainIds = getDeprecatedChainIds(chains);
+
+    return (toArray(data) as NetworkDataItem[]).filter(
+      d =>
+        !isDeprecatedChain(d.sourceChain, deprecatedChainIds) &&
+        !isDeprecatedChain(d.destinationChain, deprecatedChainIds)
+    );
+  }, [data, chains]);
+
   useEffect(() => {
     if (data && chains) {
       const AXELAR = 'axelarnet';
@@ -56,7 +71,7 @@ export function NetworkGraph({
       const _data: NetworkDataItem[] = _.orderBy(
         Object.entries(
           _.groupBy(
-            data.flatMap(d => {
+            activeData.flatMap(d => {
               if (find(AXELAR, [d.sourceChain, d.destinationChain])) {
                 return d;
               }
@@ -84,7 +99,12 @@ export function NetworkGraph({
 
       // add no traffic pairs
       chains
-        .filter(d => (!d.maintainer_id || !d.no_inflation) && d.id !== AXELAR)
+        .filter(
+          d =>
+            (!d.maintainer_id || !d.no_inflation) &&
+            d.id !== AXELAR &&
+            !d.deprecated
+        )
         .forEach(d => {
           [
             [d.id, AXELAR],
@@ -171,7 +191,7 @@ export function NetworkGraph({
 
       setGraphData({ nodes, edges });
     }
-  }, [data, setGraphData, resolvedTheme, chains]);
+  }, [data, activeData, setGraphData, resolvedTheme, chains]);
 
   useEffect(() => {
     if (!page) {
@@ -187,7 +207,7 @@ export function NetworkGraph({
   );
   const images = useImagePreloader(toArray(imagesUrl) as string[]);
   const imagesLoaded =
-    chains && Object.keys({ ...images }).length / chains.length >= 0.5;
+    !!nodes?.length && Object.keys({ ...images }).length / nodes.length >= 0.5;
 
   const nodeCanvasObject = useNodeCanvasObject(
     selectedNode,
@@ -197,7 +217,7 @@ export function NetworkGraph({
   );
   const linkCanvasObject = useLinkCanvasObject(selectedNode, resolvedTheme);
 
-  const filteredData = (toArray(data) as NetworkDataItem[]).filter(
+  const filteredData = activeData.filter(
     (d: NetworkDataItem) =>
       !selectedNode?.id ||
       find(selectedNode.id, [d.sourceChain, d.destinationChain])

--- a/src/components/NetworkGraph/NetworkGraph.utils.ts
+++ b/src/components/NetworkGraph/NetworkGraph.utils.ts
@@ -3,6 +3,7 @@ import _ from 'lodash';
 import { isString } from '@/lib/string';
 import { isNumber, toNumber } from '@/lib/number';
 import { toArray } from '@/lib/parser';
+import type { Chain } from '@/types';
 
 import type {
   GraphNode,
@@ -10,6 +11,20 @@ import type {
   ImagesMap,
   TierConfig,
 } from './NetworkGraph.types';
+
+export const getDeprecatedChainIds = (
+  chains: Chain[] | null | undefined
+): Set<string> =>
+  new Set(
+    toArray(chains)
+      .filter(d => d.deprecated && d.id)
+      .map(d => d.id.toLowerCase())
+  );
+
+export const isDeprecatedChain = (
+  id: string | undefined,
+  deprecatedChainIds: Set<string>
+): boolean => !!id && deprecatedChainIds.has(id.toLowerCase());
 
 // ---------------------------------------------------------------------------
 // Image preloading helpers

--- a/src/components/NetworkGraph/NetworkGraph.utils.ts
+++ b/src/components/NetworkGraph/NetworkGraph.utils.ts
@@ -3,7 +3,6 @@ import _ from 'lodash';
 import { isString } from '@/lib/string';
 import { isNumber, toNumber } from '@/lib/number';
 import { toArray } from '@/lib/parser';
-import type { Chain } from '@/types';
 
 import type {
   GraphNode,
@@ -11,20 +10,6 @@ import type {
   ImagesMap,
   TierConfig,
 } from './NetworkGraph.types';
-
-export const getDeprecatedChainIds = (
-  chains: Chain[] | null | undefined
-): Set<string> =>
-  new Set(
-    toArray(chains)
-      .filter(d => d.deprecated && d.id)
-      .map(d => d.id.toLowerCase())
-  );
-
-export const isDeprecatedChain = (
-  id: string | undefined,
-  deprecatedChainIds: Set<string>
-): boolean => !!id && deprecatedChainIds.has(id.toLowerCase());
 
 // ---------------------------------------------------------------------------
 // Image preloading helpers

--- a/src/components/Overview/Overview.utils.ts
+++ b/src/components/Overview/Overview.utils.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-import { getChainData } from '@/lib/config';
+import { getChainData, makeDeprecatedChainChecker } from '@/lib/config';
 import { toArray } from '@/lib/parser';
 import { find } from '@/lib/string';
 import { toNumber } from '@/lib/number';
@@ -21,22 +21,6 @@ function resolveChainId(
   const cached = lookup[key] || getChainData(key, chains)?.id;
   lookup[key] = cached;
   return cached || key;
-}
-
-function makeDeprecatedChainChecker(
-  chains: Chain[] | null | undefined
-): (key: string | undefined) => boolean {
-  const cache = new Map<string, boolean>();
-
-  return (key: string | undefined) => {
-    if (!key) return false;
-
-    if (!cache.has(key)) {
-      cache.set(key, !!getChainData(key, chains)?.deprecated);
-    }
-
-    return cache.get(key)!;
-  };
 }
 
 function buildGmpGraphItems(

--- a/src/components/Overview/Overview.utils.ts
+++ b/src/components/Overview/Overview.utils.ts
@@ -23,6 +23,22 @@ function resolveChainId(
   return cached || key;
 }
 
+function makeDeprecatedChainChecker(
+  chains: Chain[] | null | undefined
+): (key: string | undefined) => boolean {
+  const cache = new Map<string, boolean>();
+
+  return (key: string | undefined) => {
+    if (!key) return false;
+
+    if (!cache.has(key)) {
+      cache.set(key, !!getChainData(key, chains)?.deprecated);
+    }
+
+    return cache.get(key)!;
+  };
+}
+
 function buildGmpGraphItems(
   data: OverviewData,
   lookup: Record<string, string | undefined>,
@@ -123,26 +139,32 @@ export function buildChainPairs(
       ).map(d => d?.id),
     }));
 
+  const isDeprecatedChain = makeDeprecatedChainChecker(chains);
+
   return groupData(
     _.concat(
-      toArray(data.GMPStatsByChains?.source_chains).flatMap(
-        (s: SourceChainEntry) =>
+      toArray(data.GMPStatsByChains?.source_chains)
+        .filter((s: SourceChainEntry) => !isDeprecatedChain(s.key))
+        .flatMap((s: SourceChainEntry) =>
           toArray(s.destination_chains)
             .filter(
               (d: DestinationChainEntry) =>
-                !chainFocus || find(chainFocus, [s.key, d.key])
+                (!chainFocus || find(chainFocus, [s.key, d.key])) &&
+                !isDeprecatedChain(d.key)
             )
             .map((d: DestinationChainEntry) => ({
               key: `${s.key}_${d.key}`,
               num_txs: d.num_txs,
               volume: d.volume,
             }))
-      ),
+        ),
       toArray(data.transfersStats?.data)
         .filter(
           (d: TransferStatsEntry) =>
-            !chainFocus ||
-            find(chainFocus, [d.source_chain, d.destination_chain])
+            (!chainFocus ||
+              find(chainFocus, [d.source_chain, d.destination_chain])) &&
+            !isDeprecatedChain(d.source_chain) &&
+            !isDeprecatedChain(d.destination_chain)
         )
         .map((d: TransferStatsEntry) => ({
           key: `${d.source_chain}_${d.destination_chain}`,

--- a/src/components/Resources/Asset.component.tsx
+++ b/src/components/Resources/Asset.component.tsx
@@ -16,6 +16,7 @@ import type {
   NormalizedAssetAddress,
 } from './Resources.types';
 import * as styles from './Resources.styles';
+import { orderChainAddresses } from './Resources.utils';
 import { ChainIcon } from './ChainIcon.component';
 import { FocusedChainDetail } from './FocusedChainDetail.component';
 
@@ -35,25 +36,29 @@ export function Asset({ data, focusID, onFocus }: AssetProps) {
   } = { ...data };
   const asset = type === 'its' ? data.id : denom;
 
-  const chainAddresses: NormalizedAssetAddress[] = _.uniqBy(
-    toArray(
-      _.concat(
-        {
-          chain: native_chain,
-          ...(type === 'its'
-            ? data.chains?.[native_chain!]
-            : rawAddresses?.[native_chain!]),
-        },
-        Object.entries({
-          ...(type === 'its' ? data.chains : rawAddresses),
-        }).map(([k, v]) => ({ chain: k, ...(v as AssetAddressEntry) }))
-      )
-    ),
-    'chain'
-  ).map((d: NormalizedAssetAddress) => ({
-    ...d,
-    address: d.address || d.tokenAddress,
-  }));
+  const chainAddresses: NormalizedAssetAddress[] = orderChainAddresses(
+    _.uniqBy(
+      toArray(
+        _.concat(
+          {
+            chain: native_chain,
+            ...(type === 'its'
+              ? data.chains?.[native_chain!]
+              : rawAddresses?.[native_chain!]),
+          },
+          Object.entries({
+            ...(type === 'its' ? data.chains : rawAddresses),
+          }).map(([k, v]) => ({ chain: k, ...(v as AssetAddressEntry) }))
+        )
+      ),
+      'chain'
+    ).map((d: NormalizedAssetAddress) => ({
+      ...d,
+      address: d.address || d.tokenAddress,
+    })),
+    chains,
+    native_chain
+  );
 
   const isFocused = focusID === asset;
   const {

--- a/src/components/Resources/Asset.component.tsx
+++ b/src/components/Resources/Asset.component.tsx
@@ -36,26 +36,28 @@ export function Asset({ data, focusID, onFocus }: AssetProps) {
   } = { ...data };
   const asset = type === 'its' ? data.id : denom;
 
-  const chainAddresses: NormalizedAssetAddress[] = orderChainAddresses(
-    _.uniqBy(
-      toArray(
-        _.concat(
-          {
-            chain: native_chain,
-            ...(type === 'its'
-              ? data.chains?.[native_chain!]
-              : rawAddresses?.[native_chain!]),
-          },
-          Object.entries({
-            ...(type === 'its' ? data.chains : rawAddresses),
-          }).map(([k, v]) => ({ chain: k, ...(v as AssetAddressEntry) }))
-        )
-      ),
-      'chain'
-    ).map((d: NormalizedAssetAddress) => ({
-      ...d,
-      address: d.address || d.tokenAddress,
-    })),
+  const unorderedChainAddresses: NormalizedAssetAddress[] = _.uniqBy(
+    toArray(
+      _.concat(
+        {
+          chain: native_chain,
+          ...(type === 'its'
+            ? data.chains?.[native_chain!]
+            : rawAddresses?.[native_chain!]),
+        },
+        Object.entries({
+          ...(type === 'its' ? data.chains : rawAddresses),
+        }).map(([k, v]) => ({ chain: k, ...(v as AssetAddressEntry) }))
+      )
+    ),
+    'chain'
+  ).map((d: NormalizedAssetAddress) => ({
+    ...d,
+    address: d.address || d.tokenAddress,
+  }));
+
+  const chainAddresses = orderChainAddresses(
+    unorderedChainAddresses,
     chains,
     native_chain
   );

--- a/src/components/Resources/ChainIcon.component.tsx
+++ b/src/components/Resources/ChainIcon.component.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 import { Image } from '@/components/Image';
 import { Tooltip } from '@/components/Tooltip';
 import { getChainData } from '@/lib/config';
+import { toArray } from '@/lib/parser';
 
 import type { ChainIconProps } from './Resources.types';
 import * as styles from './Resources.styles';
@@ -16,7 +17,7 @@ export function ChainIcon({
   onClick,
   chains,
 }: ChainIconProps) {
-  const { name, image } = { ...getChainData(chainId, chains) };
+  const { name, image, deprecated } = { ...getChainData(chainId, chains) };
 
   const borderClass = isSelected
     ? styles.chainIconSelected
@@ -24,19 +25,30 @@ export function ChainIcon({
       ? styles.chainIconNative
       : '';
 
+  const labels = toArray([
+    chainId === nativeChain && 'Native Chain',
+    deprecated && 'Deactivated',
+  ]) as string[];
+
   return (
     <div className={styles.chainIconWrapper}>
       <Tooltip
-        content={`${name}${chainId === nativeChain ? ' (Native Chain)' : ''}`}
+        content={`${name}${labels.length > 0 ? ` (${labels.join(', ')})` : ''}`}
         className={styles.chainIconTooltip}
       >
-        <button onClick={onClick}>
+        <button
+          onClick={onClick}
+          className={clsx('block rounded-full', borderClass)}
+        >
           <Image
             src={image}
             alt=""
             width={24}
             height={24}
-            className={clsx('rounded-full', borderClass)}
+            className={clsx(
+              'rounded-full',
+              deprecated && styles.chainIconDeprecated
+            )}
           />
         </button>
       </Tooltip>

--- a/src/components/Resources/Resources.styles.ts
+++ b/src/components/Resources/Resources.styles.ts
@@ -39,6 +39,7 @@ export const chainIconSelected =
   'border-2 border-blue-600 dark:border-blue-500' as const;
 export const chainIconNative =
   'border-2 border-orange-400 dark:border-orange-500' as const;
+export const chainIconDeprecated = 'opacity-60 grayscale' as const;
 export const seeMoreButton =
   '3xl:text-sm 3xl:px-2.5 3xl:py-1.5 mb-1.5 rounded bg-zinc-100 px-1.5 py-1 text-xs font-medium text-blue-600 dark:bg-zinc-800 dark:text-blue-500' as const;
 export const focusedChainSection = 'flex flex-col gap-y-3' as const;

--- a/src/components/Resources/Resources.utils.ts
+++ b/src/components/Resources/Resources.utils.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-import { getChainData } from '@/lib/config';
+import { makeDeprecatedChainChecker } from '@/lib/config';
 import { toArray } from '@/lib/parser';
 import { equalsIgnoreCase, includesSomePatterns } from '@/lib/string';
 import type { Chain, Asset, AssetAddress } from '@/types';
@@ -30,12 +30,13 @@ export function orderChainAddresses(
   chains: Chain[] | null,
   nativeChain: string | undefined
 ): NormalizedAssetAddress[] {
+  const isDeprecatedChain = makeDeprecatedChainChecker(chains);
+
   return _.orderBy(
     chainAddresses,
     [
       (d: NormalizedAssetAddress) => d.chain !== nativeChain,
-      (d: NormalizedAssetAddress) =>
-        !!getChainData(d.chain, chains)?.deprecated,
+      (d: NormalizedAssetAddress) => isDeprecatedChain(d.chain),
     ],
     ['asc', 'asc']
   );

--- a/src/components/Resources/Resources.utils.ts
+++ b/src/components/Resources/Resources.utils.ts
@@ -1,10 +1,45 @@
 import _ from 'lodash';
 
+import { getChainData } from '@/lib/config';
 import { toArray } from '@/lib/parser';
 import { equalsIgnoreCase, includesSomePatterns } from '@/lib/string';
 import type { Chain, Asset, AssetAddress } from '@/types';
 
-import type { AssetResourceData } from './Resources.types';
+import type {
+  AssetResourceData,
+  NormalizedAssetAddress,
+} from './Resources.types';
+
+/**
+ * Orders the chains an asset is deployed on for display on an asset card.
+ *
+ * The card truncates its icon row to the first few entries, so this ordering decides which deployments a user sees before expanding.
+ * The native chain comes first, then active chains, then deprecated ones.
+ * Deprecated chains are pushed to the end rather than removed — the token still exists on them, it is just no longer bridgeable, which the greyed icon and its tooltip convey.
+ * The native chain outranks that demotion so a token whose origin chain has been deprecated still shows where it came from.
+ *
+ * Ordering is otherwise left untouched: `_.orderBy` is stable, so entries that tie keep the order they arrived in.
+ *
+ * @param chainAddresses - Deployments to order, native chain first as built by the asset card
+ * @param chains - Chain configs used to resolve each entry, may be null before the API responds
+ * @param nativeChain - Chain the asset originates from, if known
+ * @returns A new ordered array; nothing is filtered out
+ */
+export function orderChainAddresses(
+  chainAddresses: NormalizedAssetAddress[],
+  chains: Chain[] | null,
+  nativeChain: string | undefined
+): NormalizedAssetAddress[] {
+  return _.orderBy(
+    chainAddresses,
+    [
+      (d: NormalizedAssetAddress) => d.chain !== nativeChain,
+      (d: NormalizedAssetAddress) =>
+        !!getChainData(d.chain, chains)?.deprecated,
+    ],
+    ['asc', 'asc']
+  );
+}
 
 export function filterChains(
   chains: unknown,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -84,6 +84,35 @@ export const getChainData = (
   return toArray(chainsData).find((d: Chain) => d.id === id);
 };
 
+/**
+ * Builds a predicate that reports whether a chain is deprecated.
+ *
+ * Resolution goes through `getChainData`, so any identifier form the chain
+ * config knows about is accepted - id, chain_id, chain_name, maintainer_id,
+ * name or alias - not just the canonical id.
+ *
+ * The returned closure memoizes per key, so callers can use it inside filters
+ * and comparators without rescanning the chain list on every element.
+ *
+ * @param chainsData - Chain configs to resolve against, may be null before the API responds
+ * @returns Predicate that is false for falsy input and for unknown chains
+ */
+export const makeDeprecatedChainChecker = (
+  chainsData: Chain[] | null | undefined
+): ((chain: string | undefined) => boolean) => {
+  const cache = new Map<string, boolean>();
+
+  return (chain: string | undefined) => {
+    if (!chain) return false;
+
+    if (!cache.has(chain)) {
+      cache.set(chain, !!getChainData(chain, chainsData)?.deprecated);
+    }
+
+    return cache.get(chain)!;
+  };
+};
+
 export const getAssetData = (
   asset: string | null | undefined,
   assetsData: Asset[] | null | undefined


### PR DESCRIPTION
This PR removes non-bridgable chains from the statistics page and marks non-bridgable assets as deprecated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which chain pairs appear in overview and network statistics, so displayed metrics can shift; asset UI is mostly ordering and labeling with no backend or auth impact.
> 
> **Overview**
> Introduces **`makeDeprecatedChainChecker`** in config so callers can resolve any chain identifier and test the **`deprecated`** flag with memoization.
> 
> **Statistics / overview:** GMP and transfer pair aggregation (`buildChainPairs`) and the **network graph** now drop flows where either endpoint is deprecated. The graph also stops synthesizing zero-traffic links for deprecated chains, and image preload readiness is keyed off **rendered node count** instead of total chain config length.
> 
> **Resources:** Asset cards **reorder** chain deployment icons (native first, active next, deprecated last) via **`orderChainAddresses`** without removing deployments. **`ChainIcon`** adds a **Deactivated** tooltip label, grayscale styling, and moves selection borders to the button wrapper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 784bd58c8f5d805b3a8b51f05aad1eaf796572bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->