### PR TITLE
Resolve amount/denom/symbol from ibc-go v10 hex-only packet data

### DIFF
--- a/src/components/Transaction/PacketData.component.tsx
+++ b/src/components/Transaction/PacketData.component.tsx
@@ -1,13 +1,17 @@
 'use client';
 
-import { JSONView } from '@/components/JSONView';
-import { Tag } from '@/components/Tag';
-import { extractIbcPacketData } from '@/lib/chain/ibc';
+import { normalizeEvents } from '@/lib/chain/cosmos';
+import { extractIbcPacketData, type IbcEvent } from '@/lib/chain/ibc';
 import type { DataProps } from './Transaction.types';
+import { PacketDataItem } from './PacketDataItem.component';
 import * as styles from './Transaction.styles';
 
 export function PacketData({ data }: DataProps) {
-  const packets = extractIbcPacketData(data.events);
+  // Same event source as getActivities.
+  const events = normalizeEvents(
+    data as Parameters<typeof normalizeEvents>[0]
+  ) as IbcEvent[];
+  const packets = extractIbcPacketData(events);
 
   if (packets.length === 0) return null;
 
@@ -16,25 +20,10 @@ export function PacketData({ data }: DataProps) {
       <h3 className={styles.sectionTitle}>Packet data</h3>
       <div className={styles.packetDataPanel}>
         {packets.map((packet, index) => (
-          <div
+          <PacketDataItem
             key={`${packet.eventType}-${packet.sequence ?? 'unknown'}-${index}`}
-            className={styles.packetDataItem}
-          >
-            <div className={styles.packetDataHeader}>
-              <Tag className={styles.packetDataTag}>{packet.eventType}</Tag>
-              {packet.sequence && (
-                <span className={styles.packetDataSequence}>
-                  Packet #{packet.sequence}
-                </span>
-              )}
-              <span className={styles.packetDataSource}>
-                {packet.source === 'packet_data_hex'
-                  ? 'Decoded from packet_data_hex'
-                  : 'From packet_data'}
-              </span>
-            </div>
-            <JSONView value={packet.value} className={styles.packetDataJson} />
-          </div>
+            packet={packet}
+          />
         ))}
       </div>
     </section>

--- a/src/components/Transaction/PacketData.component.tsx
+++ b/src/components/Transaction/PacketData.component.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { JSONView } from '@/components/JSONView';
+import { Tag } from '@/components/Tag';
+import { extractIbcPacketData } from '@/lib/chain/ibc';
+import type { DataProps } from './Transaction.types';
+import * as styles from './Transaction.styles';
+
+export function PacketData({ data }: DataProps) {
+  const packets = extractIbcPacketData(data.events);
+
+  if (packets.length === 0) return null;
+
+  return (
+    <section className={styles.sectionWrapper}>
+      <h3 className={styles.sectionTitle}>Packet data</h3>
+      <div className={styles.packetDataPanel}>
+        {packets.map((packet, index) => (
+          <div
+            key={`${packet.eventType}-${packet.sequence ?? index}`}
+            className={styles.packetDataItem}
+          >
+            <div className={styles.packetDataHeader}>
+              <Tag className={styles.packetDataTag}>{packet.eventType}</Tag>
+              {packet.sequence && (
+                <span className={styles.packetDataSequence}>
+                  Packet #{packet.sequence}
+                </span>
+              )}
+              <span className={styles.packetDataSource}>
+                {packet.source === 'packet_data_hex'
+                  ? 'Decoded from packet_data_hex'
+                  : 'From packet_data'}
+              </span>
+            </div>
+            <JSONView value={packet.value} className={styles.packetDataJson} />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/Transaction/PacketData.component.tsx
+++ b/src/components/Transaction/PacketData.component.tsx
@@ -17,7 +17,7 @@ export function PacketData({ data }: DataProps) {
       <div className={styles.packetDataPanel}>
         {packets.map((packet, index) => (
           <div
-            key={`${packet.eventType}-${packet.sequence ?? index}`}
+            key={`${packet.eventType}-${packet.sequence ?? 'unknown'}-${index}`}
             className={styles.packetDataItem}
           >
             <div className={styles.packetDataHeader}>

--- a/src/components/Transaction/PacketDataItem.component.tsx
+++ b/src/components/Transaction/PacketDataItem.component.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { JSONView } from '@/components/JSONView';
+import { Tag } from '@/components/Tag';
+import type { PacketDataItemProps } from './Transaction.types';
+import * as styles from './Transaction.styles';
+
+export function PacketDataItem({ packet }: PacketDataItemProps) {
+  return (
+    <div className={styles.packetDataItem}>
+      <div className={styles.packetDataHeader}>
+        <Tag className={styles.packetDataTag}>{packet.eventType}</Tag>
+        {packet.sequence && (
+          <span className={styles.packetDataSequence}>
+            Packet #{packet.sequence}
+          </span>
+        )}
+        <span className={styles.packetDataSource}>
+          {packet.source === 'hex'
+            ? 'Decoded from packet_data_hex'
+            : 'From packet_data'}
+        </span>
+      </div>
+      <JSONView value={packet.value} className={styles.packetDataJson} />
+    </div>
+  );
+}

--- a/src/components/Transaction/Transaction.component.tsx
+++ b/src/components/Transaction/Transaction.component.tsx
@@ -10,6 +10,7 @@ import { getSender, getType } from '@/components/Transactions';
 import { getTransaction } from '@/lib/api/validator';
 import type { TransactionData, TransactionProps } from './Transaction.types';
 import { Info } from './Info.component';
+import { PacketData } from './PacketData.component';
 import { Data } from './Data.component';
 import * as styles from './Transaction.styles';
 
@@ -65,6 +66,7 @@ export function Transaction({ tx, initialData }: TransactionProps) {
     <Container className="sm:mt-8">
       <div className={styles.transactionContent}>
         <Info data={data} tx={tx} />
+        <PacketData data={data} />
         <Data data={data} />
       </div>
     </Container>

--- a/src/components/Transaction/Transaction.styles.ts
+++ b/src/components/Transaction/Transaction.styles.ts
@@ -39,6 +39,18 @@ export const sectionWrapper = 'flex flex-col gap-y-4' as const;
 export const sectionTitle = 'text-lg font-semibold' as const;
 export const sectionPanel =
   'flex flex-col gap-y-8 bg-zinc-50/75 px-4 py-6 dark:bg-zinc-800/25 sm:rounded-lg sm:px-6' as const;
+export const packetDataPanel =
+  'flex flex-col divide-y divide-zinc-200 overflow-hidden bg-zinc-50/75 dark:divide-zinc-700 dark:bg-zinc-800/25 sm:rounded-lg' as const;
+export const packetDataItem =
+  'flex flex-col gap-y-4 px-4 py-6 sm:px-6' as const;
+export const packetDataHeader =
+  'flex flex-wrap items-center gap-x-3 gap-y-2' as const;
+export const packetDataTag = 'w-fit !text-2xs' as const;
+export const packetDataSequence = 'text-xs font-medium' as const;
+export const packetDataSource =
+  'text-xs text-zinc-400 dark:text-zinc-500' as const;
+export const packetDataJson =
+  '!max-w-full overflow-x-auto rounded-lg bg-zinc-100 px-3 py-4 dark:bg-zinc-800 sm:px-4' as const;
 export const activityItem = 'flex flex-col gap-y-4' as const;
 export const activityRow = 'flex flex-wrap' as const;
 export const activityFieldWrapper = 'mr-3 flex flex-col gap-y-1' as const;

--- a/src/components/Transaction/Transaction.types.ts
+++ b/src/components/Transaction/Transaction.types.ts
@@ -3,6 +3,7 @@ import type {
   TransactionData as BaseTransactionData,
   TransactionActivity,
 } from '@/components/Transactions';
+import type { IbcPacketData } from '@/lib/chain/ibc';
 
 export interface TransactionData extends BaseTransactionData {
   sender?: string;
@@ -56,6 +57,10 @@ export interface ActivityItemProps {
   chains: Chain[] | null;
   assets: Asset[] | null;
   validators: Validator[] | null;
+}
+
+export interface PacketDataItemProps {
+  packet: IbcPacketData;
 }
 
 export interface EventLogEntryProps {

--- a/src/components/Transactions/Transactions.utils.test.ts
+++ b/src/components/Transactions/Transactions.utils.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @jest-environment node
+ */
+import _ from 'lodash';
+
+import { getActivities } from './Transactions.utils';
+import type { TransactionData } from './Transactions.types';
+import type { Asset } from '@/types';
+
+const toHex = (s: string) => Buffer.from(s, 'utf8').toString('hex');
+
+const PACKET_DATA_JSON = JSON.stringify({
+  amount: '1500000',
+  denom: 'uaxl',
+  receiver: 'axelar1recv',
+  sender: 'osmo1send',
+});
+const PACKET_DATA_HEX = toHex(PACKET_DATA_JSON);
+
+const ASSETS: Asset[] = [
+  { id: 'uaxl', denom: 'uaxl', symbol: 'AXL', decimals: 6 },
+];
+
+// A MsgRecvPacket falls through to the event-driven branch of getActivities,
+// where the `recv_packet` attributes become the activity via _.assign.
+const mkTx = (
+  payloadAttributes: Array<{ key: string; value: string }>
+): TransactionData => ({
+  txhash: '0xdead',
+  tx: {
+    body: { messages: [{ '@type': '/ibc.core.channel.v1.MsgRecvPacket' }] },
+  },
+  events: [
+    {
+      type: 'recv_packet',
+      attributes: [
+        { key: 'packet_src_channel', value: 'channel-2' },
+        { key: 'packet_dst_channel', value: 'channel-3' },
+        { key: 'packet_sequence', value: '77' },
+        ...payloadAttributes,
+      ],
+    },
+  ],
+});
+
+const V8 = mkTx([
+  { key: 'packet_data', value: PACKET_DATA_JSON },
+  { key: 'packet_data_hex', value: PACKET_DATA_HEX },
+]);
+const V8_RAW_ONLY = mkTx([{ key: 'packet_data', value: PACKET_DATA_JSON }]);
+const V10_HEX_ONLY = mkTx([{ key: 'packet_data_hex', value: PACKET_DATA_HEX }]);
+
+describe('getActivities: IBC packet data across the ibc-go v8 -> v10 upgrade', () => {
+  it('resolves amount, denom and symbol from a hex-only (v10) recv_packet', () => {
+    const [activity] = getActivities(V10_HEX_ONLY, ASSETS)!;
+
+    expect(activity.packet_data).toEqual({
+      amount: 1.5,
+      denom: 'uaxl',
+      receiver: 'axelar1recv',
+      sender: 'osmo1send',
+    });
+    expect(activity.symbol).toBe('AXL');
+  });
+
+  it('produces the same activity for v8 (raw + hex), v8 (raw only) and v10 (hex only)', () => {
+    const v8 = getActivities(V8, ASSETS);
+    const v8RawOnly = getActivities(V8_RAW_ONLY, ASSETS);
+    const v10 = getActivities(V10_HEX_ONLY, ASSETS);
+
+    expect(v10).toEqual(v8);
+    expect(v8RawOnly).toEqual(v8!.map(a => _.omit(a, 'packet_data_hex')));
+  });
+});

--- a/src/components/Transactions/Transactions.utils.ts
+++ b/src/components/Transactions/Transactions.utils.ts
@@ -5,6 +5,7 @@ import {
   getEventByType,
   normalizeEvents,
 } from '@/lib/chain/cosmos';
+import { normalizeIbcAttributes } from '@/lib/chain/ibc';
 import { getAssetData } from '@/lib/config';
 import { toJson, toHex, split, toArray } from '@/lib/parser';
 import {
@@ -161,10 +162,11 @@ export const getActivities = (
             symbol: assetData?.symbol,
             send_packet_data: attributes
               ? Object.fromEntries(
-                  (attributes as CosmosAttributeLike[]).map(a => [
-                    a.key,
-                    a.value,
-                  ])
+                  // Normalize hex-only (ibc-go v10) attributes into a canonical
+                  // packet_data before keying, so downstream receives packet_data.
+                  normalizeIbcAttributes(
+                    attributes as CosmosAttributeLike[]
+                  ).map(a => [a.key, a.value])
                 )
               : undefined,
             packet: d.packet,
@@ -356,6 +358,11 @@ export const getActivities = (
         return out;
       }
 
+      // Normalize hex-only (ibc-go v10) attributes so a canonical packet_data
+      // feeds event.packet_data (consumed downstream).
+      const eventAttributes = normalizeIbcAttributes(
+        cosmosEvent.attributes
+      ) as CosmosAttributeLike[];
       const event: TransactionActivity = {
         type: cosmosEvent.type,
         ...(
@@ -364,7 +371,7 @@ export const getActivities = (
           ) => Record<string, unknown>
         ).apply(
           _,
-          toArray<CosmosAttributeLike>(cosmosEvent.attributes).map(
+          toArray<CosmosAttributeLike>(eventAttributes).map(
             ({ key, value }) => {
               const attribute: Record<string, unknown> = {};
 

--- a/src/lib/chain/ibc.test.ts
+++ b/src/lib/chain/ibc.test.ts
@@ -1,0 +1,214 @@
+/**
+ * @jest-environment node
+ */
+import {
+  decodeHexStrict,
+  resolveIbcPayload,
+  normalizeIbcAttributes,
+  type IbcAttribute,
+} from './ibc';
+
+const toHex = (s: string) => Buffer.from(s, 'utf8').toString('hex');
+
+// Realistic ICS-20 packet_data used for a GMP gas payment.
+const PACKET_DATA_JSON = JSON.stringify({
+  amount: '1000000',
+  denom: 'transfer/channel-3/uaxl',
+  receiver: 'axelar1gasservice000000000000000000000000000000',
+  sender: 'osmo1sender0000000000000000000000000000000000',
+  memo: JSON.stringify({
+    source_chain: 'osmosis',
+    destination_chain: 'ethereum',
+    contract: '0xabc',
+  }),
+});
+const PACKET_DATA_HEX = toHex(PACKET_DATA_JSON);
+
+const ACK_SUCCESS_JSON = JSON.stringify({ result: 'AQ==' });
+const ACK_ERROR_JSON = JSON.stringify({ error: 'insufficient funds' });
+
+describe('decodeHexStrict', () => {
+  it('decodes valid UTF-8 hex', () => {
+    expect(decodeHexStrict(PACKET_DATA_HEX)).toBe(PACKET_DATA_JSON);
+  });
+  it('rejects non-string', () => {
+    expect(() => decodeHexStrict(123)).toThrow(/not a string/);
+  });
+  it('rejects empty', () => {
+    expect(() => decodeHexStrict('')).toThrow(/empty/);
+  });
+  it('rejects odd length', () => {
+    expect(() => decodeHexStrict('abc')).toThrow(/odd length/);
+  });
+  it('rejects non-hex characters', () => {
+    expect(() => decodeHexStrict('zz')).toThrow(/non-hex/);
+  });
+  it('rejects invalid UTF-8 (lone 0xff)', () => {
+    expect(() => decodeHexStrict('ff')).toThrow(/valid UTF-8/);
+  });
+  it('accepts a genuine U+FFFD in source', () => {
+    const s = 'a�b';
+    expect(decodeHexStrict(toHex(s))).toBe(s);
+  });
+});
+
+describe('resolveIbcPayload: packet_data', () => {
+  it('raw-only parses', () => {
+    expect(
+      resolveIbcPayload(
+        [{ key: 'packet_data', value: PACKET_DATA_JSON }],
+        'packet_data'
+      )
+    ).toEqual({ value: PACKET_DATA_JSON });
+  });
+  it('hex-only parses', () => {
+    expect(
+      resolveIbcPayload(
+        [{ key: 'packet_data_hex', value: PACKET_DATA_HEX }],
+        'packet_data'
+      )
+    ).toEqual({ value: PACKET_DATA_JSON });
+  });
+  it('matching raw + hex uses hex, no error', () => {
+    const r = resolveIbcPayload(
+      [
+        { key: 'packet_data', value: PACKET_DATA_JSON },
+        { key: 'packet_data_hex', value: PACKET_DATA_HEX },
+      ],
+      'packet_data'
+    );
+    expect(r.value).toBe(PACKET_DATA_JSON);
+    expect(r.error).toBeUndefined();
+  });
+  it('conflicting raw + hex surfaces error, prefers hex', () => {
+    const r = resolveIbcPayload(
+      [
+        { key: 'packet_data', value: '{"receiver":"tampered"}' },
+        { key: 'packet_data_hex', value: PACKET_DATA_HEX },
+      ],
+      'packet_data'
+    );
+    expect(r.value).toBe(PACKET_DATA_JSON);
+    expect(r.error).toMatch(/disagree/);
+  });
+  it('odd-length hex, no raw -> rejected', () => {
+    const r = resolveIbcPayload(
+      [{ key: 'packet_data_hex', value: 'abc' }],
+      'packet_data'
+    );
+    expect(r.value).toBeUndefined();
+    expect(r.error).toMatch(/odd length/);
+  });
+  it('non-hex -> rejected', () => {
+    const r = resolveIbcPayload(
+      [{ key: 'packet_data_hex', value: 'zzzz' }],
+      'packet_data'
+    );
+    expect(r.value).toBeUndefined();
+    expect(r.error).toMatch(/non-hex/);
+  });
+  it('invalid UTF-8 -> rejected', () => {
+    const r = resolveIbcPayload(
+      [{ key: 'packet_data_hex', value: 'ffff' }],
+      'packet_data'
+    );
+    expect(r.value).toBeUndefined();
+    expect(r.error).toMatch(/valid UTF-8/);
+  });
+  it('malformed hex WITH raw falls back to raw + error', () => {
+    const r = resolveIbcPayload(
+      [
+        { key: 'packet_data', value: PACKET_DATA_JSON },
+        { key: 'packet_data_hex', value: 'abc' },
+      ],
+      'packet_data'
+    );
+    expect(r.value).toBe(PACKET_DATA_JSON);
+    expect(r.error).toMatch(/using raw/);
+  });
+  it('empty payload -> unresolved, no error', () => {
+    expect(resolveIbcPayload([], 'packet_data')).toEqual({ value: undefined });
+  });
+  it('duplicate raw -> rejected', () => {
+    const r = resolveIbcPayload(
+      [
+        { key: 'packet_data', value: PACKET_DATA_JSON },
+        { key: 'packet_data', value: PACKET_DATA_JSON },
+      ],
+      'packet_data'
+    );
+    expect(r.value).toBeUndefined();
+    expect(r.error).toMatch(/duplicate "packet_data"/);
+  });
+  it('duplicate hex -> rejected', () => {
+    const r = resolveIbcPayload(
+      [
+        { key: 'packet_data_hex', value: PACKET_DATA_HEX },
+        { key: 'packet_data_hex', value: PACKET_DATA_HEX },
+      ],
+      'packet_data'
+    );
+    expect(r.value).toBeUndefined();
+    expect(r.error).toMatch(/duplicate "packet_data_hex"/);
+  });
+});
+
+describe('resolveIbcPayload: packet_ack', () => {
+  it('hex-only success ack', () => {
+    expect(
+      resolveIbcPayload(
+        [{ key: 'packet_ack_hex', value: toHex(ACK_SUCCESS_JSON) }],
+        'packet_ack'
+      ).value
+    ).toBe(ACK_SUCCESS_JSON);
+  });
+  it('hex-only error ack', () => {
+    expect(
+      resolveIbcPayload(
+        [{ key: 'packet_ack_hex', value: toHex(ACK_ERROR_JSON) }],
+        'packet_ack'
+      ).value
+    ).toBe(ACK_ERROR_JSON);
+  });
+});
+
+describe('normalizeIbcAttributes (whole-array parity for Object.fromEntries / _.assign)', () => {
+  it('hex-only event yields a canonical packet_data key, keeps packet_data_hex', () => {
+    const issues: string[] = [];
+    const attrs: IbcAttribute[] = [
+      { key: 'packet_sequence', value: '42' },
+      { key: 'packet_data_hex', value: PACKET_DATA_HEX },
+    ];
+    const out = normalizeIbcAttributes(attrs, (k, m) =>
+      issues.push(`${k}:${m}`)
+    );
+    const obj = Object.fromEntries(out.map(a => [a.key, a.value]));
+    // Downstream (Object.fromEntries) now sees packet_data with decoded JSON.
+    expect(obj.packet_data).toBe(PACKET_DATA_JSON);
+    expect(JSON.parse(obj.packet_data as string).denom).toBe(
+      'transfer/channel-3/uaxl'
+    );
+    expect(obj.packet_data_hex).toBe(PACKET_DATA_HEX); // preserved for diagnostics
+    expect(obj.packet_sequence).toBe('42');
+    expect(issues).toHaveLength(0);
+  });
+  it('raw-only (v8) event is unchanged in effect: packet_data present', () => {
+    const out = normalizeIbcAttributes(
+      [{ key: 'packet_data', value: PACKET_DATA_JSON }],
+      () => {}
+    );
+    expect(Object.fromEntries(out.map(a => [a.key, a.value])).packet_data).toBe(
+      PACKET_DATA_JSON
+    );
+  });
+  it('malformed hex-only event: no packet_data (degraded, not crashed), issue reported', () => {
+    const issues: string[] = [];
+    const out = normalizeIbcAttributes(
+      [{ key: 'packet_data_hex', value: 'ffff' }],
+      (k, m) => issues.push(`${k}:${m}`)
+    );
+    const obj = Object.fromEntries(out.map(a => [a.key, a.value]));
+    expect(obj.packet_data).toBeUndefined();
+    expect(issues.some(i => /valid UTF-8/.test(i))).toBe(true);
+  });
+});

--- a/src/lib/chain/ibc.test.ts
+++ b/src/lib/chain/ibc.test.ts
@@ -192,7 +192,7 @@ describe('normalizeIbcAttributes (whole-array parity for Object.fromEntries / _.
     expect(obj.packet_sequence).toBe('42');
     expect(issues).toHaveLength(0);
   });
-  it('raw-only (v8) event is unchanged in effect: packet_data present', () => {
+  it('raw-only event is unchanged in effect: packet_data present', () => {
     const out = normalizeIbcAttributes(
       [{ key: 'packet_data', value: PACKET_DATA_JSON }],
       () => {}

--- a/src/lib/chain/ibc.test.ts
+++ b/src/lib/chain/ibc.test.ts
@@ -60,7 +60,7 @@ describe('resolveIbcPayload: packet_data', () => {
         [{ key: 'packet_data', value: PACKET_DATA_JSON }],
         'packet_data'
       )
-    ).toEqual({ value: PACKET_DATA_JSON });
+    ).toEqual({ value: PACKET_DATA_JSON, source: 'raw' });
   });
   it('hex-only parses', () => {
     expect(
@@ -68,7 +68,7 @@ describe('resolveIbcPayload: packet_data', () => {
         [{ key: 'packet_data_hex', value: PACKET_DATA_HEX }],
         'packet_data'
       )
-    ).toEqual({ value: PACKET_DATA_JSON });
+    ).toEqual({ value: PACKET_DATA_JSON, source: 'hex' });
   });
   it('matching raw + hex uses hex, no error', () => {
     const r = resolveIbcPayload(
@@ -79,6 +79,7 @@ describe('resolveIbcPayload: packet_data', () => {
       'packet_data'
     );
     expect(r.value).toBe(PACKET_DATA_JSON);
+    expect(r.source).toBe('hex');
     expect(r.error).toBeUndefined();
   });
   it('conflicting raw + hex surfaces error, prefers hex', () => {
@@ -90,6 +91,7 @@ describe('resolveIbcPayload: packet_data', () => {
       'packet_data'
     );
     expect(r.value).toBe(PACKET_DATA_JSON);
+    expect(r.source).toBe('hex');
     expect(r.error).toMatch(/disagree/);
   });
   it('odd-length hex, no raw -> rejected', () => {
@@ -125,10 +127,11 @@ describe('resolveIbcPayload: packet_data', () => {
       'packet_data'
     );
     expect(r.value).toBe(PACKET_DATA_JSON);
+    expect(r.source).toBe('raw');
     expect(r.error).toMatch(/using raw/);
   });
   it('empty payload -> unresolved, no error', () => {
-    expect(resolveIbcPayload([], 'packet_data')).toEqual({ value: undefined });
+    expect(resolveIbcPayload([], 'packet_data')).toEqual({});
   });
   it('duplicate raw -> rejected', () => {
     const r = resolveIbcPayload(
@@ -202,6 +205,38 @@ describe('normalizeIbcAttributes (whole-array parity for Object.fromEntries / _.
       PACKET_DATA_JSON
     );
   });
+  it('returns non-payload attributes untouched', () => {
+    const attrs: IbcAttribute[] = [
+      { key: 'amount', value: '1000uaxl' },
+      { key: 'receiver', value: 'axelar1recv' },
+    ];
+    expect(normalizeIbcAttributes(attrs, () => {})).toEqual(attrs);
+  });
+  it('drops both raw entries when duplicated', () => {
+    const issues: string[] = [];
+    const out = normalizeIbcAttributes(
+      [
+        { key: 'packet_data', value: PACKET_DATA_JSON },
+        { key: 'packet_data', value: PACKET_DATA_JSON },
+      ],
+      (k, m) => issues.push(`${k}:${m}`)
+    );
+    expect(out).toEqual([]);
+    expect(issues.some(i => /duplicate/.test(i))).toBe(true);
+  });
+  it('resolves packet_data and packet_ack from one write_acknowledgement event', () => {
+    const out = normalizeIbcAttributes(
+      [
+        { key: 'packet_data_hex', value: PACKET_DATA_HEX },
+        { key: 'packet_ack_hex', value: toHex(ACK_SUCCESS_JSON) },
+      ],
+      () => {}
+    );
+    const obj = Object.fromEntries(out.map(a => [a.key, a.value]));
+
+    expect(obj.packet_data).toBe(PACKET_DATA_JSON);
+    expect(obj.packet_ack).toBe(ACK_SUCCESS_JSON);
+  });
   it('malformed hex-only event: no packet_data (degraded, not crashed), issue reported', () => {
     const issues: string[] = [];
     const out = normalizeIbcAttributes(
@@ -230,7 +265,7 @@ describe('extractIbcPacketData', () => {
       {
         eventType: 'send_packet',
         sequence: '42',
-        source: 'packet_data_hex',
+        source: 'hex',
         value: JSON.parse(PACKET_DATA_JSON),
       },
     ]);
@@ -244,7 +279,7 @@ describe('extractIbcPacketData', () => {
           attributes: [{ key: 'packet_data', value: PACKET_DATA_JSON }],
         },
       ])[0]?.source
-    ).toBe('packet_data');
+    ).toBe('raw');
   });
 
   it('keeps separate packets from a multi-packet transaction', () => {

--- a/src/lib/chain/ibc.test.ts
+++ b/src/lib/chain/ibc.test.ts
@@ -5,6 +5,7 @@ import {
   decodeHexStrict,
   resolveIbcPayload,
   normalizeIbcAttributes,
+  extractIbcPacketData,
   type IbcAttribute,
 } from './ibc';
 
@@ -210,5 +211,77 @@ describe('normalizeIbcAttributes (whole-array parity for Object.fromEntries / _.
     const obj = Object.fromEntries(out.map(a => [a.key, a.value]));
     expect(obj.packet_data).toBeUndefined();
     expect(issues.some(i => /valid UTF-8/.test(i))).toBe(true);
+  });
+});
+
+describe('extractIbcPacketData', () => {
+  it('extracts a displayable packet from a hex-only event', () => {
+    expect(
+      extractIbcPacketData([
+        {
+          type: 'send_packet',
+          attributes: [
+            { key: 'packet_sequence', value: '42' },
+            { key: 'packet_data_hex', value: PACKET_DATA_HEX },
+          ],
+        },
+      ])
+    ).toEqual([
+      {
+        eventType: 'send_packet',
+        sequence: '42',
+        source: 'packet_data_hex',
+        value: JSON.parse(PACKET_DATA_JSON),
+      },
+    ]);
+  });
+
+  it('accepts pre-upgrade raw-only packet data', () => {
+    expect(
+      extractIbcPacketData([
+        {
+          type: 'send_packet',
+          attributes: [{ key: 'packet_data', value: PACKET_DATA_JSON }],
+        },
+      ])[0]?.source
+    ).toBe('packet_data');
+  });
+
+  it('keeps separate packets from a multi-packet transaction', () => {
+    const events = ['1', '2'].map(sequence => ({
+      type: 'send_packet',
+      attributes: [
+        { key: 'packet_sequence', value: sequence },
+        { key: 'packet_data_hex', value: PACKET_DATA_HEX },
+      ],
+    }));
+
+    expect(extractIbcPacketData(events).map(packet => packet.sequence)).toEqual(
+      ['1', '2']
+    );
+  });
+
+  it('does not display malformed or non-object JSON', () => {
+    const issues: string[] = [];
+    const events = [
+      {
+        type: 'send_packet',
+        attributes: [{ key: 'packet_data_hex', value: toHex('{') }],
+      },
+      {
+        type: 'send_packet',
+        attributes: [{ key: 'packet_data_hex', value: toHex('null') }],
+      },
+    ];
+
+    expect(
+      extractIbcPacketData(events, (key, message) =>
+        issues.push(`${key}:${message}`)
+      )
+    ).toEqual([]);
+    expect(issues).toEqual([
+      'packet_data:decoded value is not valid JSON',
+      'packet_data:decoded JSON is not an object',
+    ]);
   });
 });

--- a/src/lib/chain/ibc.ts
+++ b/src/lib/chain/ibc.ts
@@ -1,0 +1,169 @@
+import { toArray } from '@/lib/parser';
+
+/**
+ * IBC packet attribute decoding for the ibc-go v8 -> v10 transition.
+ *
+ * ibc-go v8 emits both the raw and the hex form of the IBC payload attributes:
+ *   packet_data / packet_data_hex, packet_ack / packet_ack_hex
+ * ibc-go v10 drops the raw attributes and emits ONLY the hex form:
+ *   packet_data_hex, packet_ack_hex
+ *
+ * The *_hex value is the hexadecimal encoding of the original UTF-8 bytes.
+ *
+ * resolveIbcPayload() returns a canonical UTF-8 string for one of the two IBC
+ * payload keys (prefer hex, fall back to raw). normalizeIbcAttributes() returns
+ * a new attribute array with a synthetic canonical `packet_data` / `packet_ack`
+ * entry so that whole-array consumers (Object.fromEntries / _.assign) keep
+ * receiving `packet_data` for hex-only v10 events. Malformed input, duplicates
+ * and raw/hex mismatches are surfaced (never silently swallowed).
+ *
+ * The fallback is intentionally restricted to these two keys only — there is no
+ * generic <key>_hex fallback.
+ *
+ * Decoding uses TextDecoder/Uint8Array (browser- and server-safe) rather than
+ * Buffer, so the Transactions page can decode client-side.
+ */
+
+export interface IbcAttribute {
+  key: string;
+  value?: string | null;
+  index?: boolean;
+}
+
+export type IbcIssueHandler = (key: string, message: string) => void;
+
+// The only two keys that gained hex-only emission in ibc-go v10.
+const IBC_PAYLOAD_KEYS = ['packet_data', 'packet_ack'] as const;
+
+const HEX_KEY: Record<string, string> = {
+  packet_data: 'packet_data_hex',
+  packet_ack: 'packet_ack_hex',
+};
+
+const HEX_CHARS = /^[0-9a-fA-F]*$/;
+
+/**
+ * Strictly decode a hex string to a UTF-8 string.
+ * Rejects: non-strings, empty, odd length, non-hex characters, and byte
+ * sequences that are not valid UTF-8 (TextDecoder fatal mode).
+ * Throws Error on any violation; returns the decoded UTF-8 string otherwise.
+ */
+export const decodeHexStrict = (hex: unknown): string => {
+  if (typeof hex !== 'string') throw new Error('hex value is not a string');
+  if (hex.length === 0) throw new Error('hex value is empty');
+  if (hex.length % 2 !== 0) throw new Error('hex value has odd length');
+  if (!HEX_CHARS.test(hex))
+    throw new Error('hex value contains non-hex characters');
+
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(hex.substr(i * 2, 2), 16);
+  }
+
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch {
+    throw new Error('hex value does not decode to valid UTF-8');
+  }
+};
+
+export interface ResolvedPayload {
+  value?: string;
+  error?: string;
+}
+
+/**
+ * Resolve the canonical UTF-8 string for a single IBC payload key from an
+ * event's full attribute array. `value` is the decoded/raw canonical string, or
+ * undefined when unresolvable. `error` is a human-readable description when
+ * something was wrong (duplicate, malformed hex, or raw/hex mismatch); a
+ * mismatch still returns the canonical (hex) value alongside the error.
+ */
+export const resolveIbcPayload = (
+  attributes: IbcAttribute[] | undefined,
+  key: string
+): ResolvedPayload => {
+  const hexKey = HEX_KEY[key];
+  const list = toArray(attributes) as IbcAttribute[];
+
+  if (!hexKey) {
+    const found = list.find(a => a && a.key === key);
+    return { value: found?.value ?? undefined };
+  }
+
+  const raws = list.filter(a => a && a.key === key).map(a => a.value);
+  const hexes = list.filter(a => a && a.key === hexKey).map(a => a.value);
+
+  // Duplicates are ambiguous: reject (do not guess) but report.
+  if (raws.length > 1)
+    return { value: undefined, error: `duplicate "${key}" attributes` };
+  if (hexes.length > 1)
+    return { value: undefined, error: `duplicate "${hexKey}" attributes` };
+
+  const raw = raws[0] ?? undefined;
+  const hex = hexes[0] ?? undefined;
+
+  // No hex form present -> pre-upgrade / v8 raw-only behavior.
+  if (hex === undefined) return { value: raw ?? undefined };
+
+  let decoded: string;
+  try {
+    decoded = decodeHexStrict(hex);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    // Malformed hex must not silently fall through to the raw value: report it.
+    // Fall back to raw only when raw is present, otherwise leave unresolved.
+    if (raw !== undefined && raw !== null) {
+      return {
+        value: raw,
+        error: `"${hexKey}" ${message}; using raw "${key}"`,
+      };
+    }
+    return { value: undefined, error: `"${hexKey}" ${message}` };
+  }
+
+  // Both forms present and disagree: prefer the canonical hex value, surface it.
+  // (Equal UTF-8 strings imply equal bytes, so string comparison is exact.)
+  if (raw !== undefined && raw !== null && raw !== decoded) {
+    return {
+      value: decoded,
+      error: `"${key}" and "${hexKey}" disagree; using "${hexKey}"`,
+    };
+  }
+
+  return { value: decoded };
+};
+
+const defaultOnIssue: IbcIssueHandler = (key, message) => {
+  // No app logger in the browser; surface loudly instead of swallowing.
+  console.warn(`[ibc] attribute "${key}": ${message}`);
+};
+
+/**
+ * Return a NEW attribute array where the IBC payload keys have been collapsed to
+ * a single canonical entry holding the decoded UTF-8 string. The *_hex entries
+ * are preserved for diagnostics; existing raw entries are replaced by the
+ * canonical value. Whole-array consumers (Object.fromEntries / _.assign) that
+ * key on `packet_data` / `packet_ack` therefore keep working for hex-only v10
+ * events, exactly as they did for v8.
+ */
+export const normalizeIbcAttributes = (
+  attributes: IbcAttribute[] | undefined,
+  onIssue: IbcIssueHandler = defaultOnIssue
+): IbcAttribute[] => {
+  const list = toArray(attributes) as IbcAttribute[];
+
+  // Keep every non-payload attribute, and keep the *_hex entries as diagnostics;
+  // drop the raw payload entries so we can re-add a single canonical one.
+  const out = list.filter(
+    a => !a || !(IBC_PAYLOAD_KEYS as readonly string[]).includes(a.key)
+  );
+
+  for (const key of IBC_PAYLOAD_KEYS) {
+    const { value, error } = resolveIbcPayload(list, key);
+    if (error) onIssue(key, error);
+    if (value !== undefined) out.push({ key, value });
+  }
+
+  return out;
+};

--- a/src/lib/chain/ibc.ts
+++ b/src/lib/chain/ibc.ts
@@ -17,7 +17,7 @@ import { toArray } from '@/lib/parser';
  * receiving `packet_data` for hex-only v10 events. Malformed input, duplicates
  * and raw/hex mismatches are surfaced (never silently swallowed).
  *
- * The fallback is intentionally restricted to these two keys only — there is no
+ * The fallback is intentionally restricted to these two keys only - there is no
  * generic <key>_hex fallback.
  *
  * Decoding uses TextDecoder/Uint8Array (browser- and server-safe) rather than
@@ -30,15 +30,19 @@ export interface IbcAttribute {
   index?: boolean;
 }
 
-export type IbcIssueHandler = (key: string, message: string) => void;
+type IbcIssueHandler = (key: string, message: string) => void;
 
 // The only two keys that gained hex-only emission in ibc-go v10.
 const IBC_PAYLOAD_KEYS = ['packet_data', 'packet_ack'] as const;
 
-const HEX_KEY: Record<string, string> = {
-  packet_data: 'packet_data_hex',
-  packet_ack: 'packet_ack_hex',
-};
+type IbcPayloadKey = (typeof IBC_PAYLOAD_KEYS)[number];
+
+const hexKeyOf = (key: IbcPayloadKey): string => `${key}_hex`;
+
+// Both forms of both payload keys, for cheap "is this event IBC-shaped?" tests.
+const PAYLOAD_ATTRIBUTES = new Set<string>(
+  IBC_PAYLOAD_KEYS.flatMap(key => [key, hexKeyOf(key)])
+);
 
 const HEX_CHARS = /^[0-9a-fA-F]*$/;
 
@@ -57,7 +61,7 @@ export const decodeHexStrict = (hex: unknown): string => {
 
   const bytes = new Uint8Array(hex.length / 2);
   for (let i = 0; i < bytes.length; i++) {
-    bytes[i] = parseInt(hex.substr(i * 2, 2), 16);
+    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
   }
 
   try {
@@ -67,51 +71,54 @@ export const decodeHexStrict = (hex: unknown): string => {
   }
 };
 
-export interface ResolvedPayload {
+interface ResolvedPayload {
   value?: string;
+  /** Which attribute the returned value came from. */
+  source?: 'raw' | 'hex';
   error?: string;
 }
 
 export interface IbcPacketData {
   eventType: string;
   sequence?: string;
-  source: 'packet_data' | 'packet_data_hex';
+  source: 'raw' | 'hex';
   value: Record<string, unknown>;
+}
+
+export interface IbcEvent {
+  type?: string;
+  attributes?: IbcAttribute[];
 }
 
 /**
  * Resolve the canonical UTF-8 string for a single IBC payload key from an
  * event's full attribute array. `value` is the decoded/raw canonical string, or
- * undefined when unresolvable. `error` is a human-readable description when
- * something was wrong (duplicate, malformed hex, or raw/hex mismatch); a
- * mismatch still returns the canonical (hex) value alongside the error.
+ * undefined when unresolvable, and `source` says which attribute it came from.
+ * `error` is a human-readable description when something was wrong (duplicate,
+ * malformed hex, or raw/hex mismatch); a mismatch still returns the canonical
+ * (hex) value alongside the error.
  */
 export const resolveIbcPayload = (
   attributes: IbcAttribute[] | undefined,
-  key: string
+  key: IbcPayloadKey
 ): ResolvedPayload => {
-  const hexKey = HEX_KEY[key];
+  const hexKey = hexKeyOf(key);
   const list = toArray(attributes) as IbcAttribute[];
-
-  if (!hexKey) {
-    const found = list.find(a => a && a.key === key);
-    return { value: found?.value ?? undefined };
-  }
 
   const raws = list.filter(a => a && a.key === key).map(a => a.value);
   const hexes = list.filter(a => a && a.key === hexKey).map(a => a.value);
 
   // Duplicates are ambiguous: reject (do not guess) but report.
-  if (raws.length > 1)
-    return { value: undefined, error: `duplicate "${key}" attributes` };
-  if (hexes.length > 1)
-    return { value: undefined, error: `duplicate "${hexKey}" attributes` };
+  if (raws.length > 1) return { error: `duplicate "${key}" attributes` };
+  if (hexes.length > 1) return { error: `duplicate "${hexKey}" attributes` };
 
   const raw = raws[0] ?? undefined;
   const hex = hexes[0] ?? undefined;
 
   // No hex form present -> accept raw-only input.
-  if (hex === undefined) return { value: raw ?? undefined };
+  if (hex === undefined) {
+    return raw === undefined ? {} : { value: raw, source: 'raw' };
+  }
 
   let decoded: string;
   try {
@@ -120,25 +127,27 @@ export const resolveIbcPayload = (
     const message = e instanceof Error ? e.message : String(e);
     // Malformed hex must not silently fall through to the raw value: report it.
     // Fall back to raw only when raw is present, otherwise leave unresolved.
-    if (raw !== undefined && raw !== null) {
+    if (raw !== undefined) {
       return {
         value: raw,
+        source: 'raw',
         error: `"${hexKey}" ${message}; using raw "${key}"`,
       };
     }
-    return { value: undefined, error: `"${hexKey}" ${message}` };
+    return { error: `"${hexKey}" ${message}` };
   }
 
   // Both forms present and disagree: prefer the canonical hex value, surface it.
   // (Equal UTF-8 strings imply equal bytes, so string comparison is exact.)
-  if (raw !== undefined && raw !== null && raw !== decoded) {
+  if (raw !== undefined && raw !== decoded) {
     return {
       value: decoded,
+      source: 'hex',
       error: `"${key}" and "${hexKey}" disagree; using "${hexKey}"`,
     };
   }
 
-  return { value: decoded };
+  return { value: decoded, source: 'hex' };
 };
 
 const defaultOnIssue: IbcIssueHandler = (key, message) => {
@@ -147,18 +156,21 @@ const defaultOnIssue: IbcIssueHandler = (key, message) => {
 };
 
 /**
- * Return a NEW attribute array where the IBC payload keys have been collapsed to
- * a single canonical entry holding the decoded UTF-8 string. The *_hex entries
- * are preserved for diagnostics; existing raw entries are replaced by the
- * canonical value. Whole-array consumers (Object.fromEntries / _.assign) that
- * key on `packet_data` / `packet_ack` therefore keep working for hex-only v10
- * events, exactly as they did for v8.
+ * Return a NEW attribute array with a single canonical `packet_data` /
+ * `packet_ack` entry holding the decoded UTF-8 string. The *_hex entries are
+ * kept for diagnostics, raw entries are replaced, and unresolvable payloads
+ * (duplicates, malformed hex) are reported and left out. Whole-array consumers
+ * (Object.fromEntries / _.assign) that key on `packet_data` / `packet_ack`
+ * therefore keep working for hex-only v10 events, exactly as they did for v8.
  */
 export const normalizeIbcAttributes = (
   attributes: IbcAttribute[] | undefined,
   onIssue: IbcIssueHandler = defaultOnIssue
 ): IbcAttribute[] => {
   const list = toArray(attributes) as IbcAttribute[];
+
+  // Fast path: no IBC payload attribute in this event, nothing to decode.
+  if (!list.some(a => a && PAYLOAD_ATTRIBUTES.has(a.key))) return list;
 
   // Keep every non-payload attribute, and keep the *_hex entries as diagnostics;
   // drop the raw payload entries so we can re-add a single canonical one.
@@ -180,17 +192,16 @@ export const normalizeIbcAttributes = (
  * event attributes are never modified; this is a derived view for display.
  */
 export const extractIbcPacketData = (
-  events: Array<{ type?: string; attributes?: IbcAttribute[] }> | undefined,
+  events: IbcEvent[] | undefined,
   onIssue: IbcIssueHandler = defaultOnIssue
 ): IbcPacketData[] =>
   toArray(events).flatMap(event => {
     const attributes = toArray(event?.attributes) as IbcAttribute[];
-    const hasRaw = attributes.some(a => a?.key === 'packet_data');
-    const hasHex = attributes.some(a => a?.key === 'packet_data_hex');
 
-    if (!hasRaw && !hasHex) return [];
-
-    const { value, error } = resolveIbcPayload(attributes, 'packet_data');
+    const { value, source, error } = resolveIbcPayload(
+      attributes,
+      'packet_data'
+    );
     if (error) onIssue('packet_data', error);
     if (value === undefined) return [];
 
@@ -213,10 +224,7 @@ export const extractIbcPacketData = (
       {
         eventType: event?.type ?? 'IBC packet',
         sequence: sequence ?? undefined,
-        source:
-          hasHex && !error?.includes('using raw')
-            ? 'packet_data_hex'
-            : 'packet_data',
+        source: source === 'hex' ? 'hex' : 'raw',
         value: parsed as Record<string, unknown>,
       },
     ];

--- a/src/lib/chain/ibc.ts
+++ b/src/lib/chain/ibc.ts
@@ -103,7 +103,7 @@ export const resolveIbcPayload = (
   const raw = raws[0] ?? undefined;
   const hex = hexes[0] ?? undefined;
 
-  // No hex form present -> pre-upgrade / v8 raw-only behavior.
+  // No hex form present -> accept raw-only input.
   if (hex === undefined) return { value: raw ?? undefined };
 
   let decoded: string;

--- a/src/lib/chain/ibc.ts
+++ b/src/lib/chain/ibc.ts
@@ -72,6 +72,13 @@ export interface ResolvedPayload {
   error?: string;
 }
 
+export interface IbcPacketData {
+  eventType: string;
+  sequence?: string;
+  source: 'packet_data' | 'packet_data_hex';
+  value: Record<string, unknown>;
+}
+
 /**
  * Resolve the canonical UTF-8 string for a single IBC payload key from an
  * event's full attribute array. `value` is the decoded/raw canonical string, or
@@ -167,3 +174,50 @@ export const normalizeIbcAttributes = (
 
   return out;
 };
+
+/**
+ * Extract JSON packet payloads for the transaction details page. The original
+ * event attributes are never modified; this is a derived view for display.
+ */
+export const extractIbcPacketData = (
+  events: Array<{ type?: string; attributes?: IbcAttribute[] }> | undefined,
+  onIssue: IbcIssueHandler = defaultOnIssue
+): IbcPacketData[] =>
+  toArray(events).flatMap(event => {
+    const attributes = toArray(event?.attributes) as IbcAttribute[];
+    const hasRaw = attributes.some(a => a?.key === 'packet_data');
+    const hasHex = attributes.some(a => a?.key === 'packet_data_hex');
+
+    if (!hasRaw && !hasHex) return [];
+
+    const { value, error } = resolveIbcPayload(attributes, 'packet_data');
+    if (error) onIssue('packet_data', error);
+    if (value === undefined) return [];
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      onIssue('packet_data', 'decoded value is not valid JSON');
+      return [];
+    }
+
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      onIssue('packet_data', 'decoded JSON is not an object');
+      return [];
+    }
+
+    const sequence = attributes.find(a => a?.key === 'packet_sequence')?.value;
+
+    return [
+      {
+        eventType: event?.type ?? 'IBC packet',
+        sequence: sequence ?? undefined,
+        source:
+          hasHex && !error?.includes('using raw')
+            ? 'packet_data_hex'
+            : 'packet_data',
+        value: parsed as Record<string, unknown>,
+      },
+    ];
+  });


### PR DESCRIPTION
## What
On ibc-go v10, IBC events carry only `packet_data_hex` (no raw `packet_data`). The Transactions page turns the attribute array into keyed data via `Object.fromEntries` / `_.assign`, so downstream code that reads `packet_data` stops resolving amount, denomination and symbol. This restores it while keeping v8 events working.

## How
- New `src/lib/chain/ibc.ts`: `decodeHexStrict` (browser-safe `TextDecoder`, fatal UTF-8), `resolveIbcPayload` (prefer hex, raw fallback, reject duplicates, surface mismatch), and `normalizeIbcAttributes` — synthesizes a canonical `packet_data` from `packet_data_hex` and keeps `*_hex` for diagnostics. Restricted to the two IBC payload keys.
- `Transactions.utils.ts`: normalize attributes before both `Object.fromEntries` (`send_packet_data`) and the `_.assign` event builder that feeds `packet_data` downstream — so a v10 hex-only event carries the same `packet_data` a v8 event did (attribute-array parity, no v8 behavior change).
- Malformed payloads degrade to a missing `packet_data` + `console.warn` (no invented zeros, page never crashes).

Follows `CLAUDE.md` (helper in `src/lib/chain`).

## Tests
`src/lib/chain/ibc.test.ts` — 23 jest cases (full matrix + whole-array parity). All pass; `tsc --noEmit` clean project-wide; eslint + prettier clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how IBC event attributes are decoded and assigned into transaction activities. Malformed payloads degrade rather than crash, but incorrect decoding would mis-display transfer amounts and symbols.
> 
> **Overview**
> Restores IBC transfer amount, denom, and symbol after ibc-go v10 dropped raw `packet_data` in favor of `packet_data_hex`. `getActivities` now normalizes attributes so hex-only events still produce a canonical `packet_data` for downstream parsing, matching v8 behavior.
> 
> Adds `src/lib/chain/ibc.ts` to strictly decode hex UTF-8, prefer hex over raw, reject duplicates, and surface mismatches. The transaction details page also renders a **Packet data** section with the decoded JSON when present. Malformed payloads omit `packet_data` and warn instead of inventing values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c9ea5e9679af75c07fff1d9d6cbbe91cf282cd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->